### PR TITLE
changed required version of python-crfsuite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with io.open('HISTORY.rst') as history_file:
 
 install_requires = [
     'Click>=6.0',
-    'python-crfsuite==0.9.5',
+    'python-crfsuite==0.9.6',
     'languageflow==1.1.9a1'
 ]
 


### PR DESCRIPTION
Changed required version of python-crfsuite for underthesea to build successfully on python 3.7.0.
I did not include a test since I feel it's trivial to write a test for a trivial change, let me know if this could/should be merged of not, thanks !
 