### PR TITLE
Improve dictionary loader performance

### DIFF
--- a/underthesea/dictionary/__init__.py
+++ b/underthesea/dictionary/__init__.py
@@ -1,4 +1,7 @@
-import pickle
+try:
+    import _pickle as pickle
+except ImportError:
+    import pickle
 from os.path import join, dirname
 
 from underthesea.util.singleton import Singleton


### PR DESCRIPTION
Since python3, they support `_pickle` which does the same functionality as `pickle` but better performance.  