### PR TITLE
Add encoding='utf-8' to fix "UnicodeDecodeError: 'charmap' codec can't decode byte X in position Y: character maps to <undefined>" on Windows

### DIFF
--- a/underthesea/datasets/uit_absa_hotel/uit_absa_hotel.py
+++ b/underthesea/datasets/uit_absa_hotel/uit_absa_hotel.py
@@ -74,7 +74,7 @@ class UITABSAHotel:
         }
 
     def _extract_sentences(self, file):
-        with open(file) as f:
+        with open(file, encoding='utf-8') as f:
             content = f.read()
             sentences = content.split("\n\n")
             sentences = [self._extract_sentence(s) for s in sentences]

--- a/underthesea/datasets/uit_absa_restaurant/uit_absa_restaurant.py
+++ b/underthesea/datasets/uit_absa_restaurant/uit_absa_restaurant.py
@@ -74,7 +74,7 @@ class UITABSARestaurant:
         }
 
     def _extract_sentences(self, file):
-        with open(file) as f:
+        with open(file, encoding='utf-8') as f:
             content = f.read()
             sentences = content.split("\n\n")
             sentences = [self._extract_sentence(s) for s in sentences]


### PR DESCRIPTION
I tested on Windows 11. 
More details for this issue https://stackoverflow.com/questions/9233027/unicodedecodeerror-charmap-codec-cant-decode-byte-x-in-position-y-character