### PR TITLE
Update PyO3 API usage to support Python 3.13 and pyo3 >= 0.21

### DIFF
--- a/extensions/underthesea_core/Cargo.toml
+++ b/extensions/underthesea_core/Cargo.toml
@@ -31,7 +31,7 @@ rayon = "1.5"
 crfs = "0.1"
 
 [dependencies.pyo3]
-version = "0.15.0"
+version = "0.25.1"
 features = ["extension-module"]
 
 [dev-dependencies]

--- a/extensions/underthesea_core/src/lib.rs
+++ b/extensions/underthesea_core/src/lib.rs
@@ -2,6 +2,7 @@ extern crate regex;
 extern crate pyo3;
 
 use pyo3::prelude::*;
+use pyo3::types::PyModule;
 use std::collections::HashSet;
 
 pub mod featurizers;
@@ -32,7 +33,7 @@ impl CRFFeaturizer {
 }
 
 #[pymodule]
-fn underthesea_core(_py: Python, m: &PyModule) -> PyResult<()> {
+fn underthesea_core(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<CRFFeaturizer>()?;
     Ok(())
 }


### PR DESCRIPTION
When installing underthesea with Python 3.13 or later, the build fails for underthesea_core because the bundled PyO3 version does not support Python 3.13. The root cause is that PyO3’s API has changed: the `#[pymodule] `macro now uses `Bound<PyModule>` instead of `&PyModule`, and the add_class method only works with Bound. As a result, the old code is no longer compatible.