### PR TITLE
Remove flake8 as runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.9"
 license = "GPL-3.0"
 authors = [{ name = "Vu Anh", email = "anhv.ict91@gmail.com" }]
 dependencies = [
-    "flake8>=7.3.0",
     'Click>=6.0',
     'python-crfsuite>=0.9.6',
     'nltk>=3.8',


### PR DESCRIPTION
This PR removes `flake8` as a runtime dependency. `flake8` is a development dependency. It should not be included in runtime dependencies.