### PR TITLE
Fix TTS UnicodeDecodeError on Windows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,40 @@
+name: CI Windows
+
+on:
+  pull_request:
+    branches: [ main ]
+    types:
+      - labeled
+      - synchronize
+
+jobs:
+  ci-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Get PR Labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $PR_LABELS = gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json labels --jq '[.labels[].name]'
+          echo "$PR_LABELS"
+          echo "PR_LABELS=$PR_LABELS" >> $env:GITHUB_ENV
+      - name: Checkout
+        if: contains(env.PR_LABELS, 'ci-windows')
+        uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        if: contains(env.PR_LABELS, 'ci-windows')
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        if: contains(env.PR_LABELS, 'ci-windows')
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run encoding tests
+        if: contains(env.PR_LABELS, 'ci-windows')
+        run: |
+          python -m unittest tests.pipeline.tts.test_jax_api.TestLexiconEncoding.test_lexicon_file_exists
+          python -m unittest tests.pipeline.tts.test_jax_api.TestLexiconEncoding.test_lexicon_cannot_be_read_with_cp1252
+          python -m unittest tests.pipeline.tts.test_jax_api.TestLexiconEncoding.test_lexicon_can_be_read_with_utf8
+          python -m unittest tests.pipeline.tts.test_jax_api.TestLexiconEncoding.test_source_code_specifies_utf8_encoding

--- a/underthesea/pipeline/tts/viettts_/nat/text2mel.py
+++ b/underthesea/pipeline/tts/viettts_/nat/text2mel.py
@@ -16,7 +16,7 @@ from .model import AcousticModel, DurationModel
 
 
 def load_lexicon(fn):
-    lines = open(fn, "r").readlines()
+    lines = open(fn, "r", encoding="utf-8").readlines()
     lines = [l.lower().strip().split("\t") for l in lines]
     return dict(lines)
 


### PR DESCRIPTION
## Summary
- Fix `UnicodeDecodeError` when reading lexicon file on Windows by adding `encoding="utf-8"` to `open()` call
- Add unit tests to verify UTF-8 encoding is used
- Add Windows CI workflow

## Test plan
- [x] Unit tests pass locally (5 tests, 1 skipped due to missing voice deps)
- [ ] Windows CI workflow passes

Fixes #727