### PR TITLE
Add UVN dataset to mkdocs navigation (GH-885)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - UTS_VLC: datasets/UTS_VLC.md
       - UUD-v0.1: datasets/UUD-v0.1.md
       - UVB: datasets/UVB.md
+      - UVN: datasets/UVN.md
   - Developer:
       - Contributing: developer/contributing.md
       - Architecture: developer/architecture.md


### PR DESCRIPTION
## Summary
- Add UVN (Vietnamese News Dataset) to the Datasets section in mkdocs navigation

## Related
- Closes #885