### PR TITLE
Add Chat App for AI Agent (GH-891)

### DIFF
--- a/extensions/apps/chat/.gitignore
+++ b/extensions/apps/chat/.gitignore
@@ -1,0 +1,24 @@
+# Dependencies
+node_modules/
+package-lock.json
+
+# Build outputs
+frontend/.next/
+frontend/out/
+
+# Database
+*.db
+
+# Cache
+.cache/
+
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+
+# Logs
+*.log
+npm-debug.log*

--- a/extensions/apps/chat/README.md
+++ b/extensions/apps/chat/README.md
@@ -1,0 +1,91 @@
+# Underthesea Chat
+
+A chat application for AI Agent powered by Underthesea.
+
+## Installation
+
+```bash
+npm install @undertheseanlp/chat
+```
+
+Or install globally:
+
+```bash
+npm install -g @undertheseanlp/chat
+```
+
+## Environment Variables
+
+Set one of the following environment variable configurations:
+
+### OpenAI
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+### Azure OpenAI
+```bash
+export AZURE_OPENAI_API_KEY=...
+export AZURE_OPENAI_ENDPOINT=https://....openai.azure.com
+```
+
+## Usage
+
+### CLI
+
+```bash
+# Start the chat app
+underthesea-chat
+
+# With custom ports
+underthesea-chat --backend-port 8002 --frontend-port 3001
+```
+
+### npm scripts
+
+```bash
+cd extensions/apps/chat
+
+# Install all dependencies
+npm install
+
+# Development mode (with hot reload)
+npm run dev
+
+# Production mode
+npm start
+```
+
+This starts:
+- Frontend at http://localhost:3000
+- Backend API at http://localhost:8001
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/conversations` | List all conversations |
+| POST | `/api/conversations` | Create new conversation |
+| GET | `/api/conversations/{id}` | Get conversation with messages |
+| DELETE | `/api/conversations/{id}` | Delete conversation |
+| POST | `/api/conversations/{id}/chat` | Send message, get AI response |
+
+## Architecture
+
+```
+chat/
+├── bin/
+│   └── cli.js            # CLI entry point
+├── backend/              # Express.js backend
+│   ├── package.json
+│   └── src/
+│       ├── index.js      # Express app
+│       ├── database.js   # SQLite setup
+│       └── agent.js      # OpenAI integration
+└── frontend/             # Next.js frontend
+    └── src/
+        ├── app/          # Next.js App Router
+        ├── components/
+        ├── lib/          # API client
+        └── types/
+```

--- a/extensions/apps/chat/backend/package.json
+++ b/extensions/apps/chat/backend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@undertheseanlp/chat-backend",
+  "version": "0.1.0",
+  "description": "Chat backend for Underthesea AI Agent",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "dev": "node --watch src/index.js",
+    "start": "node src/index.js"
+  },
+  "author": "Vu Anh <anhv.ict91@gmail.com>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/undertheseanlp/underthesea.git",
+    "directory": "extensions/apps/chat/backend"
+  },
+  "keywords": [
+    "underthesea",
+    "nlp",
+    "vietnamese",
+    "chat",
+    "ai",
+    "agent"
+  ],
+  "dependencies": {
+    "better-sqlite3": "^11.7.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "openai": "^4.77.0"
+  }
+}

--- a/extensions/apps/chat/backend/src/agent.js
+++ b/extensions/apps/chat/backend/src/agent.js
@@ -1,0 +1,51 @@
+import OpenAI from 'openai';
+
+let client = null;
+
+function getClient() {
+  if (client) return client;
+
+  if (process.env.AZURE_OPENAI_API_KEY && process.env.AZURE_OPENAI_ENDPOINT) {
+    const { AzureOpenAI } = OpenAI;
+    client = new AzureOpenAI({
+      apiKey: process.env.AZURE_OPENAI_API_KEY,
+      endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+      apiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-02-01',
+    });
+  } else if (process.env.OPENAI_API_KEY) {
+    client = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    });
+  } else {
+    throw new Error(
+      'No API key found. Set OPENAI_API_KEY or AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT'
+    );
+  }
+
+  return client;
+}
+
+function getModel() {
+  if (process.env.AZURE_OPENAI_DEPLOYMENT) {
+    return process.env.AZURE_OPENAI_DEPLOYMENT;
+  }
+  return process.env.OPENAI_MODEL || 'gpt-4o-mini';
+}
+
+export async function chat(messages, systemPrompt) {
+  const openai = getClient();
+  const model = getModel();
+
+  const fullMessages = [
+    { role: 'system', content: systemPrompt },
+    ...messages,
+  ];
+
+  const response = await openai.chat.completions.create({
+    model,
+    messages: fullMessages,
+    temperature: 0.7,
+  });
+
+  return response.choices[0].message.content;
+}

--- a/extensions/apps/chat/backend/src/database.js
+++ b/extensions/apps/chat/backend/src/database.js
@@ -1,0 +1,30 @@
+import Database from 'better-sqlite3';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dbPath = join(__dirname, '..', 'chat.db');
+
+const db = new Database(dbPath);
+
+// Create tables
+db.exec(`
+  CREATE TABLE IF NOT EXISTS conversations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT DEFAULT 'New Conversation',
+    system_prompt TEXT DEFAULT 'You are a helpful assistant.',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+  );
+`);
+
+export default db;

--- a/extensions/apps/chat/backend/src/index.js
+++ b/extensions/apps/chat/backend/src/index.js
@@ -1,0 +1,149 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+// Load .env from project root
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, '..', '..', '..', '..', '..', '.env');
+dotenv.config({ path: envPath });
+
+import db from './database.js';
+import { chat } from './agent.js';
+
+const app = express();
+const PORT = process.env.PORT || 8001;
+
+app.use(cors());
+app.use(express.json());
+
+// List conversations
+app.get('/api/conversations', (req, res) => {
+  const conversations = db
+    .prepare('SELECT * FROM conversations ORDER BY updated_at DESC')
+    .all();
+  res.json(conversations);
+});
+
+// Create conversation
+app.post('/api/conversations', (req, res) => {
+  const { title = 'New Conversation', system_prompt = 'You are a helpful assistant.' } = req.body;
+
+  const result = db
+    .prepare('INSERT INTO conversations (title, system_prompt) VALUES (?, ?)')
+    .run(title, system_prompt);
+
+  const conversation = db
+    .prepare('SELECT * FROM conversations WHERE id = ?')
+    .get(result.lastInsertRowid);
+
+  res.json(conversation);
+});
+
+// Get conversation with messages
+app.get('/api/conversations/:id', (req, res) => {
+  const { id } = req.params;
+
+  const conversation = db
+    .prepare('SELECT * FROM conversations WHERE id = ?')
+    .get(id);
+
+  if (!conversation) {
+    return res.status(404).json({ detail: 'Conversation not found' });
+  }
+
+  const messages = db
+    .prepare('SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at')
+    .all(id);
+
+  res.json({ ...conversation, messages });
+});
+
+// Delete conversation
+app.delete('/api/conversations/:id', (req, res) => {
+  const { id } = req.params;
+
+  const conversation = db
+    .prepare('SELECT * FROM conversations WHERE id = ?')
+    .get(id);
+
+  if (!conversation) {
+    return res.status(404).json({ detail: 'Conversation not found' });
+  }
+
+  db.prepare('DELETE FROM conversations WHERE id = ?').run(id);
+  res.json({ message: 'Conversation deleted' });
+});
+
+// Chat - send message and get AI response
+app.post('/api/conversations/:id/chat', async (req, res) => {
+  const { id } = req.params;
+  const { content } = req.body;
+
+  const conversation = db
+    .prepare('SELECT * FROM conversations WHERE id = ?')
+    .get(id);
+
+  if (!conversation) {
+    return res.status(404).json({ detail: 'Conversation not found' });
+  }
+
+  // Save user message
+  const userResult = db
+    .prepare('INSERT INTO messages (conversation_id, role, content) VALUES (?, ?, ?)')
+    .run(id, 'user', content);
+
+  const userMessage = db
+    .prepare('SELECT * FROM messages WHERE id = ?')
+    .get(userResult.lastInsertRowid);
+
+  // Get all messages for context
+  const messages = db
+    .prepare('SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY created_at')
+    .all(id);
+
+  try {
+    // Get AI response
+    const responseText = await chat(messages, conversation.system_prompt);
+
+    // Save assistant message
+    const assistantResult = db
+      .prepare('INSERT INTO messages (conversation_id, role, content) VALUES (?, ?, ?)')
+      .run(id, 'assistant', responseText);
+
+    const assistantMessage = db
+      .prepare('SELECT * FROM messages WHERE id = ?')
+      .get(assistantResult.lastInsertRowid);
+
+    // Update conversation title if first message
+    const messageCount = db
+      .prepare('SELECT COUNT(*) as count FROM messages WHERE conversation_id = ?')
+      .get(id).count;
+
+    if (messageCount === 2) {
+      const title = content.substring(0, 50) + (content.length > 50 ? '...' : '');
+      db.prepare('UPDATE conversations SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+        .run(title, id);
+    } else {
+      db.prepare('UPDATE conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+        .run(id);
+    }
+
+    res.json({
+      user_message: userMessage,
+      assistant_message: assistantMessage,
+    });
+  } catch (error) {
+    res.status(500).json({ detail: `AI service error: ${error.message}` });
+  }
+});
+
+// Root endpoint
+app.get('/', (req, res) => {
+  res.json({ message: 'Underthesea Chat API', docs: '/api' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend running on http://localhost:${PORT}`);
+});

--- a/extensions/apps/chat/bin/cli.js
+++ b/extensions/apps/chat/bin/cli.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+const backendDir = join(rootDir, 'backend');
+const frontendDir = join(rootDir, 'frontend');
+
+const args = process.argv.slice(2);
+const backendPort = args.includes('--backend-port')
+  ? args[args.indexOf('--backend-port') + 1]
+  : '8001';
+const frontendPort = args.includes('--frontend-port')
+  ? args[args.indexOf('--frontend-port') + 1]
+  : '3000';
+
+const processes = [];
+
+function cleanup() {
+  console.log('\nShutting down...');
+  processes.forEach((p) => p.kill());
+  process.exit(0);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
+// Start backend
+console.log(`Starting backend on http://localhost:${backendPort}`);
+const backend = spawn('node', ['src/index.js'], {
+  cwd: backendDir,
+  env: { ...process.env, PORT: backendPort },
+  stdio: 'inherit',
+});
+processes.push(backend);
+
+// Start frontend
+console.log(`Starting frontend on http://localhost:${frontendPort}`);
+const frontend = spawn('npm', ['run', 'dev', '--', '-p', frontendPort], {
+  cwd: frontendDir,
+  stdio: 'inherit',
+});
+processes.push(frontend);
+
+console.log('');
+console.log('Underthesea Chat is running!');
+console.log(`  Frontend: http://localhost:${frontendPort}`);
+console.log(`  Backend:  http://localhost:${backendPort}`);
+console.log('');
+console.log('Press Ctrl+C to stop');

--- a/extensions/apps/chat/frontend/next-env.d.ts
+++ b/extensions/apps/chat/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/extensions/apps/chat/frontend/next.config.ts
+++ b/extensions/apps/chat/frontend/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  output: 'standalone',
+}
+
+export default nextConfig

--- a/extensions/apps/chat/frontend/package.json
+++ b/extensions/apps/chat/frontend/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@undertheseanlp/chat-frontend",
+  "version": "0.1.0",
+  "description": "Chat frontend for Underthesea AI Agent",
+  "author": "Vu Anh <anhv.ict91@gmail.com>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/undertheseanlp/underthesea.git",
+    "directory": "extensions/apps/chat/frontend"
+  },
+  "homepage": "https://github.com/undertheseanlp/underthesea/tree/main/extensions/apps/chat/frontend",
+  "bugs": {
+    "url": "https://github.com/undertheseanlp/underthesea/issues"
+  },
+  "keywords": [
+    "underthesea",
+    "nlp",
+    "vietnamese",
+    "chat",
+    "ai",
+    "agent"
+  ],
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "16.1.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5"
+  },
+  "files": [
+    "src",
+    "public",
+    "next.config.ts",
+    "tailwind.config.js",
+    "postcss.config.js",
+    "tsconfig.json"
+  ]
+}

--- a/extensions/apps/chat/frontend/postcss.config.js
+++ b/extensions/apps/chat/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/extensions/apps/chat/frontend/src/app/globals.css
+++ b/extensions/apps/chat/frontend/src/app/globals.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Animation for typing indicator */
+.delay-100 {
+  animation-delay: 0.1s;
+}
+
+.delay-200 {
+  animation-delay: 0.2s;
+}

--- a/extensions/apps/chat/frontend/src/app/layout.tsx
+++ b/extensions/apps/chat/frontend/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Underthesea Chat',
+  description: 'AI Chat powered by Underthesea',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/extensions/apps/chat/frontend/src/app/page.tsx
+++ b/extensions/apps/chat/frontend/src/app/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Conversation, ConversationDetail, Message } from '@/types';
+import {
+  getConversations,
+  createConversation,
+  getConversation,
+  deleteConversation,
+  sendMessage,
+} from '@/lib/api';
+import ConversationList from '@/components/ConversationList';
+import ChatWindow from '@/components/ChatWindow';
+
+export default function Home() {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [selectedConversation, setSelectedConversation] = useState<ConversationDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadConversations = useCallback(async () => {
+    try {
+      const data = await getConversations();
+      setConversations(data);
+    } catch (err) {
+      setError('Failed to load conversations');
+      console.error(err);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConversations();
+  }, [loadConversations]);
+
+  const handleSelectConversation = async (id: number) => {
+    try {
+      const data = await getConversation(id);
+      setSelectedConversation(data);
+      setError(null);
+    } catch (err) {
+      setError('Failed to load conversation');
+      console.error(err);
+    }
+  };
+
+  const handleNewConversation = async () => {
+    try {
+      const newConv = await createConversation();
+      await loadConversations();
+      await handleSelectConversation(newConv.id);
+    } catch (err) {
+      setError('Failed to create conversation');
+      console.error(err);
+    }
+  };
+
+  const handleDeleteConversation = async (id: number) => {
+    try {
+      await deleteConversation(id);
+      await loadConversations();
+      if (selectedConversation?.id === id) {
+        setSelectedConversation(null);
+      }
+    } catch (err) {
+      setError('Failed to delete conversation');
+      console.error(err);
+    }
+  };
+
+  const handleSendMessage = async (content: string) => {
+    if (!selectedConversation) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    // Optimistically add user message
+    const tempUserMessage: Message = {
+      id: Date.now(),
+      role: 'user',
+      content,
+      created_at: new Date().toISOString(),
+    };
+
+    setSelectedConversation((prev) =>
+      prev
+        ? { ...prev, messages: [...prev.messages, tempUserMessage] }
+        : null
+    );
+
+    try {
+      const response = await sendMessage(selectedConversation.id, content);
+
+      // Update with real messages
+      setSelectedConversation((prev) => {
+        if (!prev) return null;
+        const messages = prev.messages.filter((m) => m.id !== tempUserMessage.id);
+        return {
+          ...prev,
+          messages: [...messages, response.user_message, response.assistant_message],
+        };
+      });
+
+      // Reload conversations to update titles
+      await loadConversations();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send message');
+      // Remove optimistic message on error
+      setSelectedConversation((prev) =>
+        prev
+          ? { ...prev, messages: prev.messages.filter((m) => m.id !== tempUserMessage.id) }
+          : null
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex h-screen">
+      {/* Sidebar */}
+      <div className="w-64 flex-shrink-0">
+        <ConversationList
+          conversations={conversations}
+          selectedId={selectedConversation?.id ?? null}
+          onSelect={handleSelectConversation}
+          onNew={handleNewConversation}
+          onDelete={handleDeleteConversation}
+        />
+      </div>
+
+      {/* Main content */}
+      <div className="flex flex-1 flex-col bg-gray-50">
+        {error && (
+          <div className="bg-red-100 border-b border-red-400 text-red-700 px-4 py-2 text-sm">
+            {error}
+            <button
+              onClick={() => setError(null)}
+              className="ml-2 font-bold"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+
+        {selectedConversation ? (
+          <ChatWindow
+            messages={selectedConversation.messages}
+            onSendMessage={handleSendMessage}
+            isLoading={isLoading}
+            conversationTitle={selectedConversation.title}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-gray-500">
+            <div className="text-center">
+              <h2 className="text-xl font-semibold mb-2">Welcome to Underthesea Chat</h2>
+              <p>Create a new conversation or select one from the sidebar</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/extensions/apps/chat/frontend/src/components/ChatWindow.tsx
+++ b/extensions/apps/chat/frontend/src/components/ChatWindow.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Message } from '@/types';
+import MessageBubble from './MessageBubble';
+import MessageInput from './MessageInput';
+
+interface ChatWindowProps {
+  messages: Message[];
+  onSendMessage: (content: string) => void;
+  isLoading: boolean;
+  conversationTitle?: string;
+}
+
+export default function ChatWindow({
+  messages,
+  onSendMessage,
+  isLoading,
+  conversationTitle,
+}: ChatWindowProps) {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="border-b bg-white px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-800">
+          {conversationTitle || 'Select a conversation'}
+        </h2>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-6">
+        {messages.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-gray-500">
+            Start a conversation by sending a message
+          </div>
+        ) : (
+          <>
+            {messages.map((message) => (
+              <MessageBubble key={message.id} message={message} />
+            ))}
+            {isLoading && (
+              <div className="flex justify-start mb-4">
+                <div className="bg-gray-200 rounded-lg px-4 py-2">
+                  <div className="flex space-x-1">
+                    <div className="w-2 h-2 bg-gray-500 rounded-full animate-bounce" />
+                    <div className="w-2 h-2 bg-gray-500 rounded-full animate-bounce delay-100" />
+                    <div className="w-2 h-2 bg-gray-500 rounded-full animate-bounce delay-200" />
+                  </div>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </>
+        )}
+      </div>
+
+      {/* Input */}
+      <MessageInput onSend={onSendMessage} disabled={isLoading} />
+    </div>
+  );
+}

--- a/extensions/apps/chat/frontend/src/components/ConversationList.tsx
+++ b/extensions/apps/chat/frontend/src/components/ConversationList.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Conversation } from '@/types';
+
+interface ConversationListProps {
+  conversations: Conversation[];
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+  onNew: () => void;
+  onDelete: (id: number) => void;
+}
+
+export default function ConversationList({
+  conversations,
+  selectedId,
+  onSelect,
+  onNew,
+  onDelete,
+}: ConversationListProps) {
+  return (
+    <div className="flex h-full flex-col bg-gray-900 text-white">
+      {/* Header */}
+      <div className="border-b border-gray-700 p-4">
+        <button
+          onClick={onNew}
+          className="w-full rounded-lg border border-gray-600 px-4 py-2 text-sm hover:bg-gray-800"
+        >
+          + New Chat
+        </button>
+      </div>
+
+      {/* Conversations */}
+      <div className="flex-1 overflow-y-auto">
+        {conversations.length === 0 ? (
+          <div className="p-4 text-center text-gray-500">
+            No conversations yet
+          </div>
+        ) : (
+          conversations.map((conv) => (
+            <div
+              key={conv.id}
+              className={`group flex items-center justify-between border-b border-gray-800 px-4 py-3 cursor-pointer hover:bg-gray-800 ${
+                selectedId === conv.id ? 'bg-gray-800' : ''
+              }`}
+              onClick={() => onSelect(conv.id)}
+            >
+              <div className="flex-1 overflow-hidden">
+                <p className="truncate text-sm">{conv.title}</p>
+                <p className="text-xs text-gray-500">
+                  {new Date(conv.updated_at).toLocaleDateString()}
+                </p>
+              </div>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(conv.id);
+                }}
+                className="ml-2 hidden rounded p-1 text-gray-500 hover:bg-gray-700 hover:text-red-400 group-hover:block"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/extensions/apps/chat/frontend/src/components/MessageBubble.tsx
+++ b/extensions/apps/chat/frontend/src/components/MessageBubble.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Message } from '@/types';
+
+interface MessageBubbleProps {
+  message: Message;
+}
+
+export default function MessageBubble({ message }: MessageBubbleProps) {
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-4`}>
+      <div
+        className={`max-w-[70%] rounded-lg px-4 py-2 ${
+          isUser
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-200 text-gray-900'
+        }`}
+      >
+        <p className="whitespace-pre-wrap break-words">{message.content}</p>
+        <p
+          className={`text-xs mt-1 ${
+            isUser ? 'text-blue-200' : 'text-gray-500'
+          }`}
+        >
+          {new Date(message.created_at).toLocaleTimeString()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/extensions/apps/chat/frontend/src/components/MessageInput.tsx
+++ b/extensions/apps/chat/frontend/src/components/MessageInput.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState, KeyboardEvent } from 'react';
+
+interface MessageInputProps {
+  onSend: (content: string) => void;
+  disabled?: boolean;
+}
+
+export default function MessageInput({ onSend, disabled }: MessageInputProps) {
+  const [content, setContent] = useState('');
+
+  const handleSend = () => {
+    if (content.trim() && !disabled) {
+      onSend(content.trim());
+      setContent('');
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="border-t bg-white p-4">
+      <div className="flex gap-2">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message..."
+          disabled={disabled}
+          className="flex-1 resize-none rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none disabled:bg-gray-100"
+          rows={1}
+        />
+        <button
+          onClick={handleSend}
+          disabled={disabled || !content.trim()}
+          className="rounded-lg bg-blue-600 px-6 py-2 text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+          {disabled ? 'Sending...' : 'Send'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/extensions/apps/chat/frontend/src/lib/api.ts
+++ b/extensions/apps/chat/frontend/src/lib/api.ts
@@ -1,0 +1,54 @@
+import { Conversation, ConversationDetail, ChatResponse } from '@/types';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001/api';
+
+export async function getConversations(): Promise<Conversation[]> {
+  const res = await fetch(`${API_BASE}/conversations`);
+  if (!res.ok) throw new Error('Failed to fetch conversations');
+  return res.json();
+}
+
+export async function createConversation(
+  title?: string,
+  systemPrompt?: string
+): Promise<Conversation> {
+  const res = await fetch(`${API_BASE}/conversations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: title || 'New Conversation',
+      system_prompt: systemPrompt || 'You are a helpful assistant.',
+    }),
+  });
+  if (!res.ok) throw new Error('Failed to create conversation');
+  return res.json();
+}
+
+export async function getConversation(id: number): Promise<ConversationDetail> {
+  const res = await fetch(`${API_BASE}/conversations/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch conversation');
+  return res.json();
+}
+
+export async function deleteConversation(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/conversations/${id}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error('Failed to delete conversation');
+}
+
+export async function sendMessage(
+  conversationId: number,
+  content: string
+): Promise<ChatResponse> {
+  const res = await fetch(`${API_BASE}/conversations/${conversationId}/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ detail: 'Unknown error' }));
+    throw new Error(error.detail || 'Failed to send message');
+  }
+  return res.json();
+}

--- a/extensions/apps/chat/frontend/src/types/index.ts
+++ b/extensions/apps/chat/frontend/src/types/index.ts
@@ -1,0 +1,23 @@
+export interface Message {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: string;
+}
+
+export interface Conversation {
+  id: number;
+  title: string;
+  system_prompt: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ConversationDetail extends Conversation {
+  messages: Message[];
+}
+
+export interface ChatResponse {
+  user_message: Message;
+  assistant_message: Message;
+}

--- a/extensions/apps/chat/frontend/tailwind.config.js
+++ b/extensions/apps/chat/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/extensions/apps/chat/frontend/tsconfig.json
+++ b/extensions/apps/chat/frontend/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/extensions/apps/chat/package.json
+++ b/extensions/apps/chat/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@undertheseanlp/chat",
+  "version": "0.1.0",
+  "description": "Chat application for AI Agent powered by Underthesea",
+  "bin": {
+    "underthesea-chat": "./bin/cli.js"
+  },
+  "scripts": {
+    "postinstall": "cd backend && npm install && cd ../frontend && npm install",
+    "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
+    "dev:backend": "cd backend && npm run dev",
+    "dev:frontend": "cd frontend && npm run dev",
+    "start": "concurrently \"npm run start:backend\" \"npm run start:frontend\"",
+    "start:backend": "cd backend && npm start",
+    "start:frontend": "cd frontend && npm start",
+    "build": "cd frontend && npm run build"
+  },
+  "author": "Vu Anh <anhv.ict91@gmail.com>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/undertheseanlp/underthesea.git",
+    "directory": "extensions/apps/chat"
+  },
+  "keywords": [
+    "underthesea",
+    "nlp",
+    "vietnamese",
+    "chat",
+    "ai",
+    "agent"
+  ],
+  "dependencies": {
+    "concurrently": "^8.2.2"
+  }
+}


### PR DESCRIPTION
## Summary

- Add chat application at `extensions/apps/chat/` with Next.js frontend and Express.js backend
- Add CLI command `underthesea chat` to start both servers
- Publish npm packages for easy installation

## npm Packages

| Package | Version |
|---------|---------|
| [@undertheseanlp/chat](https://www.npmjs.com/package/@undertheseanlp/chat) | 0.1.0 |
| [@undertheseanlp/chat-backend](https://www.npmjs.com/package/@undertheseanlp/chat-backend) | 0.1.0 |
| [@undertheseanlp/chat-frontend](https://www.npmjs.com/package/@undertheseanlp/chat-frontend) | 0.1.0 |

## Usage

```bash
# Install globally
npm install -g @undertheseanlp/chat

# Set API key
export OPENAI_API_KEY=sk-...

# Start chat app
underthesea-chat
```

## Test plan

- [ ] Install package: `npm install -g @undertheseanlp/chat`
- [ ] Set OPENAI_API_KEY environment variable
- [ ] Run `underthesea-chat`
- [ ] Open http://localhost:3000
- [ ] Create conversation, send message, verify AI response

Closes #891