### PR TITLE
Add macos-15-intel runner for x86 macOS wheel builds

### DIFF
--- a/.github/workflows/release-pypi-core.yml
+++ b/.github/workflows/release-pypi-core.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-15-intel, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `macos-15-intel` to macOS build matrix alongside `macos-latest`
- Restores x86 macOS wheel builds after `macos-13` deprecation
- `macos-15-intel` available until August 2027

Fixes #823

Based on feedback from @BLKSerene in #859.

## Test plan
- [ ] Verify workflow runs successfully on `macos-15-intel` runner
- [ ] Verify wheels are built for both x86_64 and ARM64 architectures