### PR TITLE
refactor(word_tokenize): replace python-crfsuite with underthesea-core

### DIFF
--- a/underthesea/models/fast_crf_sequence_tagger.py
+++ b/underthesea/models/fast_crf_sequence_tagger.py
@@ -2,8 +2,7 @@ from os.path import join
 from pathlib import Path
 
 import joblib
-import pycrfsuite
-from underthesea_core import CRFFeaturizer
+from underthesea_core import CRFFeaturizer, CRFTagger
 
 
 class FastCRFSequenceTagger:
@@ -28,8 +27,8 @@ class FastCRFSequenceTagger:
     def load(self, base_path):
         # print(base_path)
         model_path = str(Path(base_path) / self.path_model)
-        estimator = pycrfsuite.Tagger()
-        estimator.open(model_path)
+        estimator = CRFTagger()
+        estimator.load(model_path)
         features = joblib.load(join(base_path, self.path_features))
         dictionary = joblib.load(join(base_path, self.path_dictionary))
         featurizer = CRFFeaturizer(features, dictionary)


### PR DESCRIPTION
## Summary

- Replace `pycrfsuite.Tagger` with `underthesea_core.CRFTagger` in `FastCRFSequenceTagger`
- This is the first step of #907 (word_tokenize module only)

## Verification

- All 43 word_tokenize tests pass
- Output is identical between python-crfsuite and underthesea_core.CRFTagger

```
python-crfsuite tags: ['B-W', 'I-W', 'B-W', 'I-W', ...]
underthesea_core tags: ['B-W', 'I-W', 'B-W', 'I-W', ...]
Tags identical: True
```

## Test plan

- [x] Run `uv run python -m unittest discover tests.pipeline.word_tokenize`
- [x] Verify output matches python-crfsuite