### PR TITLE
refactor(pos_tag): replace python-crfsuite with underthesea-core

### DIFF
--- a/underthesea/pipeline/pos_tag/model_crf.py
+++ b/underthesea/pipeline/pos_tag/model_crf.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 
-import pycrfsuite
+from underthesea_core import CRFTagger
 
 from underthesea.util.singleton import Singleton
 
@@ -11,9 +11,9 @@ from .tagged_feature import word2features
 @Singleton
 class CRFPOSTagPredictor:
     def __init__(self):
-        self.model = pycrfsuite.Tagger()
+        self.model = CRFTagger()
         filepath = join(dirname(__file__), "pos_crf_2017_10_11.bin")
-        self.model.open(filepath)
+        self.model.load(filepath)
 
         template = [
             "T[-2].lower", "T[-1].lower", "T[0].lower", "T[1].lower",


### PR DESCRIPTION
## Summary

- Replace `pycrfsuite.Tagger` with `underthesea_core.CRFTagger` in `CRFPOSTagPredictor`
- Part of #907

## Verification

- All 4 pos_tag tests pass
- Output identical between python-crfsuite and underthesea_core

```
python-crfsuite: ['N', 'N', 'N', 'A', 'E', 'Np', 'V', 'V']
underthesea_core: ['N', 'N', 'N', 'A', 'E', 'Np', 'V', 'V']
Identical: True
```

## Test plan

- [x] Run `uv run python -m unittest discover tests.pipeline.pos_tag`
- [x] Verify output matches python-crfsuite