### PR TITLE
refactor: remove python-crfsuite dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ license = "GPL-3.0"
 authors = [{ name = "Vu Anh", email = "anhv.ict91@gmail.com" }]
 dependencies = [
     'Click>=6.0',
-    'python-crfsuite>=0.9.6',
     'tqdm',
     'requests',
     'joblib',


### PR DESCRIPTION
## Summary

Remove `python-crfsuite` from dependencies. All CRF functionality now uses `underthesea-core`.

**Closes #907**

## Changes

- Remove `python-crfsuite>=0.9.6` from `pyproject.toml` dependencies

## Migration completed in previous PRs

| Component | PR |
|-----------|-----|
| FastCRFSequenceTagger (word_tokenize) | #909 |
| CRFPOSTagPredictor (pos_tag) | #912 |
| CRFNERPredictor, CRFChunkingPredictor (ner, chunking) | #913 |
| CRFTrainer + cleanup unused files | #914 |

## Test plan

- [ ] CI tests pass without python-crfsuite