### PR TITLE
fix(docs): enable blog in docusaurus config

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -31,6 +31,10 @@ const config = {
           sidebarPath: './sidebars.js',
           editUrl: 'https://github.com/undertheseanlp/underthesea/tree/main/docusaurus/',
         },
+        blog: {
+          showReadingTime: true,
+          editUrl: 'https://github.com/undertheseanlp/underthesea/tree/main/docusaurus/',
+        },
         theme: {
           customCss: './src/css/custom.css',
         },
@@ -76,6 +80,11 @@ const config = {
             position: 'left',
           },
           {
+            to: '/blog',
+            label: 'Blog',
+            position: 'left',
+          },
+          {
             href: 'https://github.com/undertheseanlp/underthesea',
             label: 'GitHub',
             position: 'right',
@@ -114,6 +123,10 @@ const config = {
           {
             title: 'More',
             items: [
+              {
+                label: 'Blog',
+                to: '/blog',
+              },
               {
                 label: 'GitHub',
                 href: 'https://github.com/undertheseanlp/underthesea',


### PR DESCRIPTION
## Summary

Fix blog not showing by enabling blog preset in docusaurus config.

## Changes

- Add `blog` preset configuration  
- Add Blog link to navbar
- Add Blog link to footer

## After this fix

Blog URL: https://undertheseanlp.github.io/underthesea/blog