### PR TITLE
fix(docs): add homepage for docusaurus site

### DIFF
--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Layout from '@theme/Layout';
+import styles from './index.module.css';
+
+function HomepageHeader() {
+  const {siteConfig} = useDocusaurusContext();
+  return (
+    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+      <div className="container">
+        <img src="img/logo.png" alt="Underthesea Logo" width="150" />
+        <h1 className="hero__title">{siteConfig.title}</h1>
+        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <div className={styles.buttons}>
+          <Link
+            className="button button--secondary button--lg"
+            to="/docs/intro">
+            Get Started
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function Feature({title, description}) {
+  return (
+    <div className={clsx('col col--4')}>
+      <div className="text--center padding-horiz--md">
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </div>
+    </div>
+  );
+}
+
+const FeatureList = [
+  {
+    title: 'Easy to Use',
+    description: 'Simple API for Vietnamese NLP tasks. Just import and use.',
+  },
+  {
+    title: 'Production Ready',
+    description: 'Pre-trained models for word segmentation, POS tagging, NER, and more.',
+  },
+  {
+    title: 'Fast & Efficient',
+    description: 'Rust-powered CRF engine for high-performance inference.',
+  },
+];
+
+export default function Home() {
+  const {siteConfig} = useDocusaurusContext();
+  return (
+    <Layout
+      title={`${siteConfig.title}`}
+      description="Open-source Vietnamese Natural Language Processing Toolkit">
+      <HomepageHeader />
+      <main>
+        <section className={styles.features}>
+          <div className="container">
+            <div className="row">
+              {FeatureList.map((props, idx) => (
+                <Feature key={idx} {...props} />
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/docusaurus/src/pages/index.module.css
+++ b/docusaurus/src/pages/index.module.css
@@ -1,0 +1,20 @@
+.heroBanner {
+  padding: 4rem 0;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.features {
+  display: flex;
+  align-items: center;
+  padding: 2rem 0;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary

Fix 404 on homepage by adding `src/pages/index.js`.

## Changes

- Add landing page with logo, tagline, and "Get Started" button
- Add 3 feature highlights (Easy to Use, Production Ready, Fast & Efficient)

## After this fix

Homepage: https://undertheseanlp.github.io/underthesea/