### PR TITLE
fix(docs): update links from /docs/intro to /docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -99,7 +99,7 @@ const config = {
             items: [
               {
                 label: 'Getting Started',
-                to: '/docs/intro',
+                to: '/docs',
               },
               {
                 label: 'API Reference',

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/docs">
             Get Started
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- Fixed broken links pointing to `/docs/intro` which returns 404
- The `intro.md` has `slug: /` which renders at `/docs`, not `/docs/intro`
- Updated homepage "Get Started" button and footer links