### PR TITLE
fix(ci): remove target-cpu=native for portable wheel builds

### DIFF
--- a/.github/workflows/release-pypi-core.yml
+++ b/.github/workflows/release-pypi-core.yml
@@ -40,6 +40,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install maturin
         run: pip install maturin
+      - name: Remove target-cpu=native for portable binary
+        run: rm -f ./extensions/underthesea_core/.cargo/config.toml
       - name: Build sdist
         working-directory: ./extensions/underthesea_core
         run: maturin sdist
@@ -67,6 +69,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install maturin
         run: pip install maturin
+      - name: Remove target-cpu=native for portable binary
+        run: rm -f ./extensions/underthesea_core/.cargo/config.toml
       - name: Build wheel
         working-directory: ./extensions/underthesea_core
         run: |
@@ -95,6 +99,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: Install maturin
       run: pip install maturin
+    - name: Remove target-cpu=native for portable binary
+      run: Remove-Item -Force -ErrorAction SilentlyContinue .\extensions\underthesea_core\.cargo\config.toml
     - name: Build wheel
       working-directory: ./extensions/underthesea_core
       run: |
@@ -125,6 +131,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: Install maturin
       run: pip install maturin
+    - name: Remove target-cpu=native for portable binary
+      run: rm -f ./extensions/underthesea_core/.cargo/config.toml
     - name: Build wheel
       working-directory: ./extensions/underthesea_core
       run: |


### PR DESCRIPTION
## Summary

- Remove `.cargo/config.toml` before building wheels in release workflow to avoid GLIBC_2.33 dependency
- The config contains `target-cpu=native` which optimizes for the build machine's CPU, causing compatibility issues on systems with older GLIBC versions
- Applied fix to all platforms: Linux, Windows, macOS, and source distribution

Fixes #922

## Test plan

- [ ] Verify CI passes
- [ ] Release new version and test on system with older GLIBC