### PR TITLE
chore(underthesea_core): bump version to 3.1.1

### DIFF
--- a/extensions/underthesea_core/Cargo.toml
+++ b/extensions/underthesea_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "underthesea_core"
-version = "3.1.0"
+version = "3.1.1"
 homepage = "https://github.com/undertheseanlp/underthesea/tree/main/extensions/underthesea_core"
 repository = "https://github.com/undertheseanlp/underthesea/"
 authors = ["Vu Anh <anhv.ict91@gmail.com>"]


### PR DESCRIPTION
## Summary

Release with fix for GLIBC_2.33 compatibility issue (#922)

## Changes

- Bump underthesea_core version from 3.1.0 to 3.1.1