### PR TITLE
chore(underthesea_core): bump version to 3.1.2

### DIFF
--- a/extensions/underthesea_core/Cargo.toml
+++ b/extensions/underthesea_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "underthesea_core"
-version = "3.1.1"
+version = "3.1.2"
 homepage = "https://github.com/undertheseanlp/underthesea/tree/main/extensions/underthesea_core"
 repository = "https://github.com/undertheseanlp/underthesea/"
 authors = ["Vu Anh <anhv.ict91@gmail.com>"]


### PR DESCRIPTION
Release with manylinux build fix for GLIBC compatibility (#922)