### PR TITLE
docs(blog): simplify rust text classifier blog title

### DIFF
--- a/docs/blog/2026-02-03-rust-text-classifier.md
+++ b/docs/blog/2026-02-03-rust-text-classifier.md
@@ -1,11 +1,11 @@
 ---
 slug: rust-text-classifier
-title: Rust-Powered Text Classification - 273x Faster Inference
+title: Rust-Powered Text Classification
 authors: [rain1024]
 tags: [rust, performance, classification, nlp]
 ---
 
-# Rust-Powered Text Classification: 273x Faster Inference
+# Rust-Powered Text Classification
 
 In underthesea v9.2.9, we've completely rewritten the text classification pipeline using our Rust-based `TextClassifier`. This delivers up to **273x faster inference** compared to the previous sklearn-based implementation.
 


### PR DESCRIPTION
## Summary
- Remove "273x Faster Inference" from blog post title

## Test plan
- [ ] Verify blog post renders correctly on docusaurus