### PR TITLE
Add crates.io release workflow for underthesea_core

### DIFF
--- a/.github/workflows/release-crates-core.yml
+++ b/.github/workflows/release-crates-core.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Dry run
         run: cargo publish --dry-run
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish to crates.io
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `release-crates-core.yml` GitHub Actions workflow to publish `underthesea_core` to crates.io
- Triggered by the same `underthesea-core-v*` tag used for PyPI release
- Verifies tag version matches `Cargo.toml` before publishing
- Runs `cargo publish --dry-run` before actual publish

## Setup required

Add `CRATES_IO_TOKEN` secret to the repository settings:
1. Go to https://crates.io/settings/tokens
2. Create a new token with `publish-new` and `publish-update` scopes
3. Add as repository secret at Settings > Secrets > Actions

## Usage

Same tag triggers both PyPI and crates.io release:
```bash
git tag underthesea-core-v3.2.0
git push origin underthesea-core-v3.2.0
```