### PR TITLE
Add underthesea_core API documentation

### DIFF
--- a/docs/docs/api/core/crf.md
+++ b/docs/docs/api/core/crf.md
@@ -1,0 +1,221 @@
+# CRF (Conditional Random Fields)
+
+Classes for training, loading, and running CRF sequence labeling models.
+
+## CRFTrainer
+
+Train a CRF model with L-BFGS or Structured Perceptron optimization.
+
+### Usage
+
+```python
+from underthesea_core import CRFTrainer
+
+X_train = [
+    [["word=Tôi", "is_upper=False"], ["word=yêu", "is_upper=False"],
+     ["word=Việt", "is_upper=True"], ["word=Nam", "is_upper=True"]],
+]
+y_train = [
+    ["O", "O", "B-LOC", "I-LOC"],
+]
+
+trainer = CRFTrainer(
+    loss_function="lbfgs",
+    l1_penalty=1.0,
+    l2_penalty=0.001,
+    max_iterations=100,
+    verbose=1,
+)
+model = trainer.train(X_train, y_train)
+model.save("ner_model.bin")
+```
+
+### Constructor
+
+```python
+CRFTrainer(
+    loss_function="lbfgs",
+    l1_penalty=0.0,
+    l2_penalty=0.01,
+    learning_rate=0.1,
+    max_iterations=100,
+    averaging=True,
+    verbose=1,
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `loss_function` | `str` | `"lbfgs"` | `"lbfgs"` (recommended) or `"perceptron"` |
+| `l1_penalty` | `float` | `0.0` | L1 regularization coefficient |
+| `l2_penalty` | `float` | `0.01` | L2 regularization coefficient |
+| `learning_rate` | `float` | `0.1` | Learning rate (perceptron only) |
+| `max_iterations` | `int` | `100` | Maximum training iterations |
+| `averaging` | `bool` | `True` | Use averaged perceptron (perceptron only) |
+| `verbose` | `int` | `1` | Verbosity: 0=quiet, 1=progress, 2=detailed |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `train(X, y)` | `CRFModel` | Train on sequences X (list of feature lists) and labels y |
+| `set_l1_penalty(penalty)` | `None` | Set L1 regularization penalty |
+| `set_l2_penalty(penalty)` | `None` | Set L2 regularization penalty |
+| `set_max_iterations(max_iter)` | `None` | Set maximum iterations |
+| `get_model()` | `CRFModel` | Get the current model |
+
+---
+
+## CRFModel
+
+Stores trained CRF model weights, labels, and features. Supports save/load.
+
+### Usage
+
+```python
+from underthesea_core import CRFModel
+
+# Load a saved model
+model = CRFModel.load("ner_model.bin")
+print(model.num_labels)        # number of labels
+print(model.num_attributes)    # number of attributes
+print(model.get_labels())      # list of label names
+
+# Create with predefined labels
+model = CRFModel.with_labels(["O", "B-LOC", "I-LOC"])
+```
+
+### Constructor
+
+```python
+CRFModel()
+```
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `load(path)` | `CRFModel` | Load model from file |
+| `with_labels(labels)` | `CRFModel` | Create model with predefined labels |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `num_labels` | `int` | Number of labels |
+| `num_attributes` | `int` | Number of attributes |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `save(path)` | `None` | Save model to file (CRFsuite format) |
+| `get_labels()` | `list[str]` | Get all label names |
+| `num_state_features()` | `int` | Get number of state features |
+| `num_transition_features()` | `int` | Get number of transition features |
+| `l2_norm_squared()` | `float` | Get L2 norm squared of all weights |
+| `l1_norm()` | `float` | Get L1 norm of all weights |
+
+---
+
+## CRFTagger
+
+Load a trained CRF model and make predictions on sequences.
+
+### Usage
+
+```python
+from underthesea_core import CRFTagger, CRFModel
+
+# Load directly
+tagger = CRFTagger()
+tagger.load("ner_model.bin")
+
+# Or create from model
+model = CRFModel.load("ner_model.bin")
+tagger = CRFTagger.from_model(model)
+
+# Predict
+features = [
+    ["word=Tôi", "is_upper=False"],
+    ["word=sống", "is_upper=False"],
+    ["word=ở", "is_upper=False"],
+    ["word=Hà", "is_upper=True"],
+    ["word=Nội", "is_upper=True"],
+]
+labels = tagger.tag(features)
+# ['O', 'O', 'O', 'B-LOC', 'I-LOC']
+
+# Get labels with score
+labels, score = tagger.tag_with_score(features)
+
+# Get marginal probabilities
+marginals = tagger.marginals(features)
+```
+
+### Constructor
+
+```python
+CRFTagger()
+```
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `from_model(model)` | `CRFTagger` | Create tagger from a `CRFModel` |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `load(path)` | `None` | Load model from file |
+| `tag(features)` | `list[str]` | Predict labels for a sequence |
+| `tag_with_score(features)` | `(list[str], float)` | Predict labels with sequence score |
+| `marginals(features)` | `list[list[float]]` | Get marginal probabilities per position and label |
+| `labels()` | `list[str]` | Get all label names |
+| `num_labels()` | `int` | Get number of labels |
+
+---
+
+## CRFFeaturizer
+
+Extract features from tokenized sentences for CRF models.
+
+### Usage
+
+```python
+from underthesea_core import CRFFeaturizer
+
+features = ["T[-1]", "T[0]", "T[1]"]
+dictionary = set(["sinh viên"])
+featurizer = CRFFeaturizer(features, dictionary)
+
+sentences = [[["sinh", "X"], ["viên", "X"], ["đi", "X"], ["học", "X"]]]
+result = featurizer.process(sentences)
+# [[['T[-1]=BOS', 'T[0]=sinh', 'T[1]=viên'],
+#   ['T[-1]=sinh', 'T[0]=viên', 'T[1]=đi'],
+#   ['T[-1]=viên', 'T[0]=đi', 'T[1]=học'],
+#   ['T[-1]=đi', 'T[0]=học', 'T[1]=EOS']]]
+```
+
+### Constructor
+
+```python
+CRFFeaturizer(feature_configs, dictionary)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `feature_configs` | `list[str]` | Feature template strings (e.g., `["T[-1]", "T[0]", "T[1]"]`) |
+| `dictionary` | `set[str]` | Dictionary of known words/phrases |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `process(sentences)` | `list[list[list[str]]]` | Extract features from tokenized sentences |

--- a/docs/docs/api/core/index.md
+++ b/docs/docs/api/core/index.md
@@ -1,0 +1,42 @@
+# underthesea_core
+
+High-performance Rust extension for underthesea, providing ML models and text processing tools with Python bindings via PyO3.
+
+## Installation
+
+```bash
+pip install underthesea-core
+```
+
+## What's Included
+
+| Module | Classes | Description |
+|--------|---------|-------------|
+| [CRF](./crf) | `CRFTrainer`, `CRFModel`, `CRFTagger`, `CRFFeaturizer` | Conditional Random Fields for sequence labeling |
+| [Logistic Regression](./lr) | `LRTrainer`, `LRModel`, `LRClassifier` | Logistic regression for text classification |
+| [Text Classifier](./text-classifier) | `TextClassifier`, `LinearSVC`, `Label`, `Sentence` | End-to-end TF-IDF + SVM text classification pipeline |
+| [TF-IDF](./tfidf) | `TfIdfVectorizer` | TF-IDF vectorization with n-gram support |
+| [Text Preprocessor](./text-preprocessor) | `TextPreprocessor` | Vietnamese text preprocessing pipeline |
+
+## Quick Start
+
+```python
+from underthesea_core import CRFTrainer, CRFTagger, CRFModel
+
+# Train a CRF model
+trainer = CRFTrainer(loss_function="lbfgs", max_iterations=100)
+model = trainer.train(X_train, y_train)
+model.save("model.bin")
+
+# Load and predict
+tagger = CRFTagger()
+tagger.load("model.bin")
+labels = tagger.tag(features)
+```
+
+## Performance
+
+- Built with Rust for optimal processing speed
+- L-BFGS optimizer with OWL-QN for L1 regularization
+- 10x faster feature lookup with flat data structure
+- 1.24x faster than python-crfsuite for word segmentation

--- a/docs/docs/api/core/lr.md
+++ b/docs/docs/api/core/lr.md
@@ -1,0 +1,176 @@
+# Logistic Regression
+
+Classes for training and running logistic regression classifiers.
+
+## LRTrainer
+
+Train a logistic regression model with SGD optimization.
+
+### Usage
+
+```python
+from underthesea_core import LRTrainer
+
+X_train = [
+    ["word=tốt", "len=3"],
+    ["word=xấu", "len=3"],
+    ["word=đẹp", "len=3"],
+]
+y_train = ["positive", "negative", "positive"]
+
+trainer = LRTrainer(
+    l2_penalty=0.01,
+    learning_rate=0.1,
+    max_epochs=100,
+    verbose=1,
+)
+model = trainer.train(X_train, y_train)
+model.save("lr_model.bin")
+```
+
+### Constructor
+
+```python
+LRTrainer(
+    l1_penalty=0.0,
+    l2_penalty=0.01,
+    learning_rate=0.1,
+    max_epochs=100,
+    batch_size=1,
+    tol=1e-4,
+    verbose=1,
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `l1_penalty` | `float` | `0.0` | L1 regularization (lasso) |
+| `l2_penalty` | `float` | `0.01` | L2 regularization (ridge) |
+| `learning_rate` | `float` | `0.1` | Learning rate for SGD |
+| `max_epochs` | `int` | `100` | Maximum training epochs |
+| `batch_size` | `int` | `1` | Mini-batch size (1 = pure SGD) |
+| `tol` | `float` | `1e-4` | Convergence tolerance for early stopping |
+| `verbose` | `int` | `1` | Verbosity: 0=quiet, 1=progress, 2=detailed |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `train(X, y)` | `LRModel` | Train on feature lists X and labels y |
+| `set_l1_penalty(penalty)` | `None` | Set L1 regularization |
+| `set_l2_penalty(penalty)` | `None` | Set L2 regularization |
+| `set_learning_rate(lr)` | `None` | Set learning rate |
+| `set_max_epochs(epochs)` | `None` | Set maximum epochs |
+| `set_batch_size(size)` | `None` | Set batch size |
+| `get_model()` | `LRModel` | Get the current model |
+
+---
+
+## LRModel
+
+Stores trained logistic regression model weights and class labels.
+
+### Usage
+
+```python
+from underthesea_core import LRModel
+
+# Load a saved model
+model = LRModel.load("lr_model.bin")
+print(model.num_classes)    # number of classes
+print(model.num_features)   # number of features
+print(model.get_classes())  # list of class labels
+
+# Create with predefined classes
+model = LRModel.with_classes(["positive", "negative"])
+```
+
+### Constructor
+
+```python
+LRModel()
+```
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `load(path)` | `LRModel` | Load model from file |
+| `with_classes(classes)` | `LRModel` | Create model with predefined classes |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `num_classes` | `int` | Number of classes |
+| `num_features` | `int` | Number of features |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `save(path)` | `None` | Save model to file |
+| `get_classes()` | `list[str]` | Get all class labels |
+| `num_weights()` | `int` | Get number of non-zero weights |
+| `l2_norm_squared()` | `float` | Get L2 norm squared of all weights |
+| `l1_norm()` | `float` | Get L1 norm of all weights |
+
+---
+
+## LRClassifier
+
+Load a trained LR model and make predictions.
+
+### Usage
+
+```python
+from underthesea_core import LRClassifier
+
+# Load from file
+classifier = LRClassifier.load("lr_model.bin")
+
+# Or create from model
+from underthesea_core import LRModel
+model = LRModel.load("lr_model.bin")
+classifier = LRClassifier.from_model(model)
+
+# Predict
+features = ["word=tốt", "len=3"]
+label = classifier.predict(features)
+
+# Predict with probability
+label, prob = classifier.predict_with_prob(features)
+
+# Get probability distribution
+proba = classifier.predict_proba(features)
+# [("positive", 0.85), ("negative", 0.15)]
+
+# Get top-k predictions
+top2 = classifier.predict_top_k(features, k=2)
+```
+
+### Constructor
+
+```python
+LRClassifier()
+```
+
+### Static Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `load(path)` | `LRClassifier` | Load classifier from file |
+| `from_model(model)` | `LRClassifier` | Create classifier from an `LRModel` |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `predict(features)` | `str` | Predict the most likely class |
+| `predict_with_prob(features)` | `(str, float)` | Predict with probability |
+| `predict_proba(features)` | `list[(str, float)]` | Get probability distribution over all classes |
+| `predict_top_k(features, k)` | `list[(str, float)]` | Get top-k most likely classes with probabilities |
+| `num_classes()` | `int` | Get number of classes |
+| `classes()` | `list[str]` | Get all class labels |

--- a/docs/docs/api/core/text-classifier.md
+++ b/docs/docs/api/core/text-classifier.md
@@ -1,0 +1,234 @@
+# Text Classifier
+
+End-to-end text classification combining TF-IDF vectorization and Linear SVM, running entirely in Rust for maximum performance.
+
+## TextClassifier
+
+Unified TF-IDF + SVM pipeline that avoids Python-Rust boundary overhead for intermediate vectors.
+
+### Usage
+
+```python
+from underthesea_core import TextClassifier
+
+texts = [
+    "sản phẩm rất tốt",
+    "hàng đẹp giá rẻ",
+    "hàng xấu quá",
+    "tệ lắm không mua nữa",
+]
+labels = ["positive", "positive", "negative", "negative"]
+
+clf = TextClassifier(max_features=20000, ngram_range=(1, 2), c=1.0)
+clf.fit(texts, labels)
+
+# Single prediction
+label = clf.predict("sản phẩm tốt")
+
+# Prediction with confidence
+label, score = clf.predict_with_score("sản phẩm tốt")
+
+# Batch prediction
+labels = clf.predict_batch(["sản phẩm tốt", "hàng xấu"])
+
+# Save/load
+clf.save("classifier.bin")
+clf = TextClassifier.load("classifier.bin")
+```
+
+### Constructor
+
+```python
+TextClassifier(
+    max_features=20000,
+    ngram_range=(1, 2),
+    min_df=1,
+    max_df=1.0,
+    c=1.0,
+    max_iter=1000,
+    tol=0.1,
+    preprocessor=None,
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_features` | `int` | `20000` | Maximum vocabulary size |
+| `ngram_range` | `(int, int)` | `(1, 2)` | Min and max n-gram range |
+| `min_df` | `int` | `1` | Minimum document frequency |
+| `max_df` | `float` | `1.0` | Maximum document frequency ratio |
+| `c` | `float` | `1.0` | SVM regularization parameter |
+| `max_iter` | `int` | `1000` | Maximum SVM training iterations |
+| `tol` | `float` | `0.1` | Convergence tolerance |
+| `preprocessor` | `TextPreprocessor` | `None` | Optional text preprocessor |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `is_fitted` | `bool` | Whether the model has been trained |
+| `n_features` | `int` | Vocabulary size |
+| `classes` | `list[str]` | Class labels |
+| `preprocessor` | `TextPreprocessor` | The preprocessor (if set) |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `fit(texts, labels)` | `None` | Train on texts and labels |
+| `predict(text)` | `str` | Predict label for a single text |
+| `predict_with_score(text)` | `(str, float)` | Predict with confidence score |
+| `predict_batch(texts)` | `list[str]` | Predict labels for multiple texts |
+| `predict_with_scores(texts)` | `list[(str, float)]` | Batch predict with scores |
+| `predict_sentence(sentence)` | `None` | Predict and add labels to a `Sentence` object |
+| `save(path)` | `None` | Save model to binary file |
+| `load(path)` | `TextClassifier` | Load model from binary file (static) |
+
+### With Preprocessor
+
+```python
+from underthesea_core import TextClassifier, TextPreprocessor
+
+pp = TextPreprocessor()
+clf = TextClassifier(preprocessor=pp)
+clf.fit(texts, labels)
+
+# Teencode is auto-expanded before prediction
+clf.predict("sp ko tốt")  # "sp" → "sản phẩm", "ko" → "không"
+```
+
+---
+
+## LinearSVC
+
+LIBLINEAR-style linear SVM using Dual Coordinate Descent. Used internally by `TextClassifier`, but also available standalone.
+
+### Usage
+
+```python
+from underthesea_core import LinearSVC
+
+svm = LinearSVC()
+svm.fit(features, labels, c=1.0, max_iter=1000, tol=0.1)
+
+label = svm.predict(features_single)
+labels = svm.predict_batch(features_batch)
+
+svm.save("svm.bin")
+svm = LinearSVC.load("svm.bin")
+```
+
+### Constructor
+
+```python
+LinearSVC()
+```
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `classes` | `list[str]` | Class labels |
+| `n_features` | `int` | Number of features |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `fit(features, labels, c=1.0, max_iter=1000, tol=0.1)` | `None` | Train the SVM classifier |
+| `predict(features)` | `str` | Predict label for a single instance |
+| `predict_batch(batch)` | `list[str]` | Predict labels for a batch |
+| `save(path)` | `None` | Save model to file |
+| `load(path)` | `LinearSVC` | Load model from file (static) |
+
+### `fit` Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `features` | `list[list[float]]` | | Dense feature vectors |
+| `labels` | `list[str]` | | Class labels |
+| `c` | `float` | `1.0` | Regularization parameter |
+| `max_iter` | `int` | `1000` | Maximum iterations |
+| `tol` | `float` | `0.1` | Convergence tolerance |
+
+---
+
+## Label
+
+A classification label with value and confidence score. Compatible with the underthesea API.
+
+### Usage
+
+```python
+from underthesea_core import Label
+
+label = Label("positive", 0.95)
+print(label.value)  # "positive"
+print(label.score)  # 0.95
+```
+
+### Constructor
+
+```python
+Label(value, score=1.0)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `value` | `str` | | Label text |
+| `score` | `float` | `1.0` | Confidence score (clamped to 0.0-1.0) |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `value` | `str` | Label text (read/write) |
+| `score` | `float` | Confidence score (read/write) |
+
+---
+
+## Sentence
+
+A text sentence with associated labels. Compatible with the underthesea API.
+
+### Usage
+
+```python
+from underthesea_core import Sentence, Label
+
+sentence = Sentence("sản phẩm rất tốt")
+sentence.add_label(Label("positive", 0.95))
+print(sentence.text)    # "sản phẩm rất tốt"
+print(sentence.labels)  # [positive (0.9500)]
+```
+
+### Constructor
+
+```python
+Sentence(text="", labels=None)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `text` | `str` | `""` | Sentence text |
+| `labels` | `list[Label]` | `None` | Initial labels |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `text` | `str` | Sentence text (read/write) |
+| `labels` | `list[Label]` | Associated labels (read/write) |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_label(label)` | `None` | Add a single label |
+| `add_labels(labels)` | `None` | Add multiple labels |

--- a/docs/docs/api/core/text-preprocessor.md
+++ b/docs/docs/api/core/text-preprocessor.md
@@ -1,0 +1,124 @@
+# TextPreprocessor
+
+Configurable Vietnamese text preprocessing pipeline. Serializable with the `TextClassifier` model so preprocessing config always travels with the model.
+
+## Pipeline Steps
+
+Applied in order:
+
+1. Unicode NFC normalization
+2. Lowercase
+3. URL removal
+4. Repeated character normalization (`"đẹppp"` → `"đẹpp"`)
+5. Punctuation normalization (`"!!!"` → `"!"`, `"????"` → `"?"`)
+6. Teencode expansion (`"ko"` → `"không"`, `"dc"` → `"được"`)
+7. Negation marking (`"không tốt"` → `"không NEG_tốt"`)
+
+## Usage
+
+```python
+from underthesea_core import TextPreprocessor
+
+# Default Vietnamese preprocessing
+pp = TextPreprocessor()
+pp.transform("Sản phẩm ko đẹp lắm!!!")
+# "sản phẩm không NEG_đẹp NEG_lắm!"
+
+# Batch processing
+results = pp.transform_batch(["Ko đẹp", "SP tốt lắm!!!"])
+# ["không NEG_đẹp", "sản phẩm tốt lắm!"]
+
+# Custom teencode dictionary
+pp = TextPreprocessor(teencode={"ko": "không", "dc": "được"})
+
+# Custom negation words and window
+pp = TextPreprocessor(
+    negation_words=["không", "chưa", "chẳng"],
+    negation_window=3,
+)
+
+# Disable specific steps
+pp = TextPreprocessor(lowercase=False, remove_urls=False)
+
+# Disable teencode and negation entirely
+pp = TextPreprocessor(teencode=None, negation_words=None, use_defaults=False)
+```
+
+## Constructor
+
+```python
+TextPreprocessor(
+    lowercase=True,
+    unicode_normalize=True,
+    remove_urls=True,
+    normalize_repeated_chars=True,
+    normalize_punctuation=True,
+    teencode=None,
+    negation_words=None,
+    negation_window=2,
+    use_defaults=True,
+)
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `lowercase` | `bool` | `True` | Convert text to lowercase |
+| `unicode_normalize` | `bool` | `True` | Apply Unicode NFC normalization |
+| `remove_urls` | `bool` | `True` | Remove URLs (http/https/www) |
+| `normalize_repeated_chars` | `bool` | `True` | Reduce 3+ repeated chars to 2 |
+| `normalize_punctuation` | `bool` | `True` | Reduce repeated punctuation |
+| `teencode` | `dict \| None` | `None` | Custom teencode dictionary. With `use_defaults=True`, defaults to built-in Vietnamese teencode |
+| `negation_words` | `list[str] \| None` | `None` | Custom negation words. With `use_defaults=True`, defaults to built-in Vietnamese negation words |
+| `negation_window` | `int` | `2` | Number of words after negation word to mark with `NEG_` prefix |
+| `use_defaults` | `bool` | `True` | When `True`, use Vietnamese defaults for teencode/negation if not provided. When `False`, `None` means disabled |
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `teencode` | `dict \| None` | Current teencode dictionary |
+| `negation_words` | `list[str] \| None` | Current negation words |
+| `negation_window` | `int` | Current negation window size |
+
+## Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `transform(text)` | `str` | Preprocess a single text string |
+| `transform_batch(texts)` | `list[str]` | Preprocess a list of texts |
+
+## Default Teencode Dictionary
+
+| Teencode | Expansion |
+|----------|-----------|
+| `ko`, `k`, `hok`, `hem` | không |
+| `dc`, `đc`, `dk` | được |
+| `sp` | sản phẩm |
+| `bt`, `bth` | bình thường |
+| `ok`, `oke` | tốt |
+| `tks`, `thanks`, `thank` | cảm ơn |
+| `ntn` | như thế nào |
+| `mn` | mọi người |
+| `cx`, `cg` | cũng |
+| `vs` | với |
+| ... | *(30+ rules total)* |
+
+## Default Negation Words
+
+`không`, `chẳng`, `chả`, `chưa`, `đừng`, `ko`, `hok`, `hem`, `chăng`
+
+## With TextClassifier
+
+```python
+from underthesea_core import TextClassifier, TextPreprocessor
+
+pp = TextPreprocessor()
+clf = TextClassifier(preprocessor=pp)
+clf.fit(texts, labels)
+
+# Preprocessor is saved together with the model
+clf.save("model.bin")
+clf = TextClassifier.load("model.bin")  # preprocessor is restored
+```

--- a/docs/docs/api/core/tfidf.md
+++ b/docs/docs/api/core/tfidf.md
@@ -1,0 +1,90 @@
+# TfIdfVectorizer
+
+TF-IDF vectorization with n-gram support, L2 normalization, and sublinear TF scaling.
+
+## Usage
+
+```python
+from underthesea_core import TfIdfVectorizer
+
+documents = [
+    "sản phẩm rất tốt",
+    "hàng đẹp giá rẻ",
+    "sản phẩm kém chất lượng",
+]
+
+vectorizer = TfIdfVectorizer(max_features=10000, ngram_range=(1, 2))
+vectorizer.fit(documents)
+
+# Sparse transform
+sparse = vectorizer.transform("sản phẩm tốt")
+# [(0, 0.577), (3, 0.577), (7, 0.577)]
+
+# Dense transform
+dense = vectorizer.transform_dense("sản phẩm tốt")
+# [0.577, 0.0, 0.0, 0.577, ...]
+
+# Feature strings for LRClassifier
+features = vectorizer.transform_to_features("sản phẩm tốt")
+# ["tfidf_0=0.5774", "tfidf_3=0.5774", ...]
+
+# Fit and transform in one step
+sparse_vectors = vectorizer.fit_transform(documents)
+
+# Save/load
+vectorizer.save("vectorizer.bin")
+vectorizer = TfIdfVectorizer.load("vectorizer.bin")
+```
+
+## Constructor
+
+```python
+TfIdfVectorizer(
+    min_df=1,
+    max_df=1.0,
+    max_features=0,
+    sublinear_tf=False,
+    lowercase=True,
+    ngram_range=(1, 1),
+    min_token_length=2,
+    norm=True,
+)
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `min_df` | `int` | `1` | Minimum document frequency |
+| `max_df` | `float` | `1.0` | Maximum document frequency ratio |
+| `max_features` | `int` | `0` | Maximum vocabulary size (0 = unlimited) |
+| `sublinear_tf` | `bool` | `False` | Use sublinear TF scaling (1 + log(tf)) |
+| `lowercase` | `bool` | `True` | Convert text to lowercase |
+| `ngram_range` | `(int, int)` | `(1, 1)` | Min and max n-gram range |
+| `min_token_length` | `int` | `2` | Minimum token length |
+| `norm` | `bool` | `True` | Apply L2 normalization |
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `vocab_size` | `int` | Vocabulary size |
+| `n_docs` | `int` | Number of documents used for fitting |
+
+## Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `fit(documents)` | `None` | Fit the vectorizer on a list of documents |
+| `transform(document)` | `list[(int, float)]` | Transform to sparse TF-IDF (feature_index, value) |
+| `transform_dense(document)` | `list[float]` | Transform to dense TF-IDF vector |
+| `transform_to_features(document)` | `list[str]` | Transform to feature strings for `LRClassifier` |
+| `fit_transform(documents)` | `list[list[(int, float)]]` | Fit and transform in one step |
+| `is_fitted()` | `bool` | Check if the vectorizer has been fitted |
+| `get_feature_names()` | `list[str]` | Get vocabulary words in order |
+| `get_idf()` | `list[float]` | Get IDF values for all features |
+| `top_features_by_idf(n)` | `list[(str, float)]` | Get top n features by IDF value |
+| `get_index(word)` | `int \| None` | Get index of a word in vocabulary |
+| `get_word(index)` | `str \| None` | Get word at a given index |
+| `save(path)` | `None` | Save vectorizer to file |
+| `load(path)` | `TfIdfVectorizer` | Load vectorizer from file (static) |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -55,6 +55,18 @@ const sidebars = {
         'api/agent',
       ],
     },
+    {
+      type: 'category',
+      label: 'underthesea_core',
+      items: [
+        'api/core/index',
+        'api/core/crf',
+        'api/core/lr',
+        'api/core/text-classifier',
+        'api/core/tfidf',
+        'api/core/text-preprocessor',
+      ],
+    },
   ],
   datasetsSidebar: [
     {


### PR DESCRIPTION
## Summary
- Add 6 new documentation pages under `docs/api/core/` covering all 12 Python classes exposed by the `underthesea_core` Rust extension (CRF, Logistic Regression, TextClassifier, LinearSVC, TfIdfVectorizer, TextPreprocessor, Label, Sentence)
- Each page includes description, usage examples, constructor signatures, parameter tables, and method tables
- Add `underthesea_core` category to the API Reference sidebar in `sidebars.js`

## Test plan
- [ ] CI `build` (Documentation) check passes
- [ ] Verify pages render at `/docs/api/core`
- [ ] Verify sidebar navigation shows underthesea_core section under API Reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)