### PR TITLE
docs: rebrand Underthesea as Agentic AI Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@
 </p>
 
 <h3 align="center">
-Open-source Vietnamese Natural Language Process Toolkit
+Open-source Agentic AI Toolkit
 </h3>
 
 `Underthesea` is:
 
-🌊 **A Vietnamese NLP toolkit** with AI Agent capabilities. Underthesea is a suite of open source Python modules supporting research and development in [Vietnamese Natural Language Processing](https://github.com/undertheseanlp/underthesea) and Agentic AI.
+🌊 **An Agentic AI Toolkit.** Since v9.3.0, Underthesea is an open-source Agentic AI Toolkit with built-in Vietnamese NLP capabilities. It provides multi-provider AI Agent support and a suite of Python modules for [Vietnamese Natural Language Processing](https://github.com/undertheseanlp/underthesea).
 
 🎁 [**Support Us!**](#-support-us) Every bit of support helps us achieve our goals. Thank you so much. 💝💝💝
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -24,12 +24,10 @@ slug: /
   </a>
 </p>
 
-**Underthesea** is a suite of open source Python modules, datasets, and tutorials supporting research and development in Vietnamese Natural Language Processing.
+**Underthesea** is an open-source Agentic AI Toolkit with built-in Vietnamese NLP capabilities. Since v9.3.0, it provides multi-provider AI Agent support (OpenAI, Azure OpenAI, Anthropic Claude, Google Gemini) with zero external LLM SDK dependencies, alongside a suite of Python modules for Vietnamese Natural Language Processing.
 
-We provide an extremely easy API to quickly apply pretrained NLP models to your Vietnamese text.
-
-:::success[New in v9.1.5]
-Conversational AI Agent is here! Use `agent("Xin chào")` to chat with an AI assistant specialized in Vietnamese NLP.
+:::success[New in v9.3.0]
+Underthesea is now an Agentic AI Toolkit! Multi-provider Agent with streaming, tool calling, and multi-session support — all with zero external dependencies.
 :::
 
 ## Installation

--- a/docs/versioned_docs/version-9.3.0/intro.md
+++ b/docs/versioned_docs/version-9.3.0/intro.md
@@ -24,12 +24,10 @@ slug: /
   </a>
 </p>
 
-**Underthesea** is a suite of open source Python modules, datasets, and tutorials supporting research and development in Vietnamese Natural Language Processing.
+**Underthesea** is an open-source Agentic AI Toolkit with built-in Vietnamese NLP capabilities. Since v9.3.0, it provides multi-provider AI Agent support (OpenAI, Azure OpenAI, Anthropic Claude, Google Gemini) with zero external LLM SDK dependencies, alongside a suite of Python modules for Vietnamese Natural Language Processing.
 
-We provide an extremely easy API to quickly apply pretrained NLP models to your Vietnamese text.
-
-:::success[New in v9.1.5]
-Conversational AI Agent is here! Use `agent("Xin chào")` to chat with an AI assistant specialized in Vietnamese NLP.
+:::success[New in v9.3.0]
+Underthesea is now an Agentic AI Toolkit! Multi-provider Agent with streaming, tool calling, and multi-session support — all with zero external dependencies.
 :::
 
 ## Installation


### PR DESCRIPTION
## Summary
- Update README tagline from "Open-source Vietnamese Natural Language Process Toolkit" to "Open-source Agentic AI Toolkit"
- Update project description in README and docs to reflect that since v9.3.0, Underthesea is an Agentic AI Toolkit with built-in Vietnamese NLP capabilities
- Update callout box in docs from "New in v9.1.5" to "New in v9.3.0" highlighting the Agentic AI Toolkit transformation

## Files changed
- `README.md`
- `docs/docs/intro.md`
- `docs/versioned_docs/version-9.3.0/intro.md`