### PR TITLE
fix(security): bump next 16.1.6 -> 16.2.3

### DIFF
--- a/extensions/apps/chat/frontend/package.json
+++ b/extensions/apps/chat/frontend/package.json
@@ -28,7 +28,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "16.1.6",
+    "next": "16.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Summary

- Bump `next` from 16.1.6 to 16.2.3 in `extensions/apps/chat/frontend` to resolve all 6 remaining Dependabot vulnerabilities (1 high, 4 moderate, 1 low)

## Test plan

- [ ] CI checks pass (lint, tests)