### PR TITLE
Add agent tracing (local + Langfuse)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ prompt = [
     "openai"
 ]
 agent = []
+trace = [
+    "langfuse>=2.0.0"
+]
 test = [
     "nose==1.3.7"
 ]

--- a/tests/agent/test_trace.py
+++ b/tests/agent/test_trace.py
@@ -1,0 +1,897 @@
+"""Tests for the agent trace module (LocalTracer, LangfuseTracer, Agent integration)."""
+
+import json
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+MOCK_POST = "underthesea.agent.providers._http.post_json"
+
+
+def _resp(content="Hello!", tool_calls=None):
+    """Build a mock OpenAI-style response."""
+    msg = {"role": "assistant", "content": content}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return {
+        "choices": [{"message": msg, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+    }
+
+
+def _tool_call_resp(name, arguments, content=None, call_id="call_1"):
+    """Build a mock response with a tool call."""
+    return _resp(
+        content=content,
+        tool_calls=[{
+            "id": call_id,
+            "type": "function",
+            "function": {"name": name, "arguments": json.dumps(arguments)},
+        }],
+    )
+
+
+# ======================================================================
+# BaseTracer / extract_usage
+# ======================================================================
+
+
+class TestExtractUsage(TestCase):
+    def test_openai_usage(self):
+        from underthesea.agent.trace.base import extract_usage
+        raw = {"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}
+        usage = extract_usage(raw)
+        self.assertEqual(usage, {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15})
+
+    def test_anthropic_usage(self):
+        from underthesea.agent.trace.base import extract_usage
+        raw = {"usage": {"input_tokens": 20, "output_tokens": 10}}
+        usage = extract_usage(raw)
+        self.assertEqual(usage["input_tokens"], 20)
+        self.assertEqual(usage["output_tokens"], 10)
+
+    def test_gemini_usage(self):
+        from underthesea.agent.trace.base import extract_usage
+        raw = {"usageMetadata": {"promptTokenCount": 30, "candidatesTokenCount": 15, "totalTokenCount": 45}}
+        usage = extract_usage(raw)
+        self.assertEqual(usage, {"input_tokens": 30, "output_tokens": 15, "total_tokens": 45})
+
+    def test_none_input(self):
+        from underthesea.agent.trace.base import extract_usage
+        self.assertIsNone(extract_usage(None))
+        self.assertIsNone(extract_usage({}))
+        self.assertIsNone(extract_usage("not a dict"))
+
+
+# ======================================================================
+# LocalTracer
+# ======================================================================
+
+
+class TestLocalTracer(TestCase):
+    def setUp(self):
+        self.trace_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.trace_dir, ignore_errors=True)
+
+    def _make_tracer(self, console=False):
+        from underthesea.agent.trace.local import LocalTracer
+        return LocalTracer(trace_dir=self.trace_dir, console=console)
+
+    def test_basic_trace_lifecycle(self):
+        tracer = self._make_tracer()
+        tid = tracer.start_trace(name="test", input="hello")
+        self.assertIsInstance(tid, str)
+        self.assertEqual(len(tid), 12)
+
+        tracer.end_trace(tid, output="world")
+
+        # Verify file was created
+        trace = tracer.get_trace(tid)
+        self.assertIsNotNone(trace)
+        self.assertEqual(trace["name"], "test")
+        self.assertEqual(trace["input"], "hello")
+        self.assertEqual(trace["output"], "world")
+        self.assertEqual(trace["status"], "ok")
+        self.assertIn("duration_ms", trace)
+
+    def test_generation_span(self):
+        tracer = self._make_tracer()
+        tid = tracer.start_trace(name="test", input="hi")
+
+        sid = tracer.start_generation(tid, name="llm.chat", model="gpt-4")
+        tracer.end_generation(
+            sid, output="response",
+            usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+        )
+        tracer.end_trace(tid, output="done")
+
+        trace = tracer.get_trace(tid)
+        self.assertEqual(len(trace["spans"]), 1)
+        span = trace["spans"][0]
+        self.assertEqual(span["type"], "generation")
+        self.assertEqual(span["model"], "gpt-4")
+        self.assertEqual(span["usage"]["input_tokens"], 100)
+        self.assertIn("duration_ms", span)
+
+    def test_tool_span(self):
+        tracer = self._make_tracer()
+        tid = tracer.start_trace(name="test", input="calc")
+
+        sid = tracer.start_span(tid, name="tool.calculator", input={"expr": "1+1"})
+        tracer.end_span(sid, output="2")
+        tracer.end_trace(tid, output="done")
+
+        trace = tracer.get_trace(tid)
+        self.assertEqual(len(trace["spans"]), 1)
+        span = trace["spans"][0]
+        self.assertEqual(span["type"], "span")
+        self.assertEqual(span["name"], "tool.calculator")
+        self.assertEqual(span["input"], {"expr": "1+1"})
+        self.assertEqual(span["output"], "2")
+
+    def test_error_trace(self):
+        tracer = self._make_tracer()
+        tid = tracer.start_trace(name="test", input="fail")
+        tracer.end_trace(tid, status="error", error="something broke")
+
+        trace = tracer.get_trace(tid)
+        self.assertEqual(trace["status"], "error")
+        self.assertEqual(trace["error"], "something broke")
+
+    def test_list_traces(self):
+        tracer = self._make_tracer()
+        for i in range(3):
+            tid = tracer.start_trace(name=f"test-{i}", input=f"msg-{i}")
+            tracer.end_trace(tid, output=f"out-{i}")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 3)
+
+    def test_list_traces_limit(self):
+        tracer = self._make_tracer()
+        for i in range(5):
+            tid = tracer.start_trace(name=f"test-{i}", input=f"msg-{i}")
+            tracer.end_trace(tid, output=f"out-{i}")
+
+        traces = tracer.list_traces(limit=2)
+        self.assertEqual(len(traces), 2)
+
+    def test_get_nonexistent_trace(self):
+        tracer = self._make_tracer()
+        self.assertIsNone(tracer.get_trace("nonexistent"))
+
+    def test_print_trace(self):
+        tracer = self._make_tracer()
+        tid = tracer.start_trace(name="print-test", input="hello")
+        sid = tracer.start_generation(tid, name="llm.chat", model="gpt-4")
+        tracer.end_generation(
+            sid, output="response",
+            usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+        tracer.end_trace(tid, output="done")
+
+        # Should not raise
+        trace = tracer.get_trace(tid)
+        tracer.print_trace(trace)
+        tracer.print_trace(tid)
+
+    def test_console_output(self):
+        """Console mode should not raise."""
+        tracer = self._make_tracer(console=True)
+        tid = tracer.start_trace(name="console-test", input="hello")
+        sid = tracer.start_generation(tid, name="llm.chat", model="gpt-4")
+        tracer.end_generation(sid, output="response")
+        sid2 = tracer.start_span(tid, name="tool.calc", input={"x": 1})
+        tracer.end_span(sid2, output="result")
+        tracer.end_trace(tid, output="done")
+
+    def test_multiple_spans(self):
+        tracer = self._make_tracer()
+        tid = tracer.start_trace(name="multi", input="test")
+
+        g1 = tracer.start_generation(tid, name="llm #1", model="gpt-4")
+        tracer.end_generation(g1, output={"content": None, "tool_calls": [{"name": "calc"}]})
+
+        t1 = tracer.start_span(tid, name="tool.calc", input={"expr": "2+2"})
+        tracer.end_span(t1, output="4")
+
+        g2 = tracer.start_generation(tid, name="llm #2", model="gpt-4")
+        tracer.end_generation(g2, output="The answer is 4")
+
+        tracer.end_trace(tid, output="The answer is 4")
+
+        trace = tracer.get_trace(tid)
+        self.assertEqual(len(trace["spans"]), 3)
+        self.assertEqual(trace["spans"][0]["type"], "generation")
+        self.assertEqual(trace["spans"][1]["type"], "span")
+        self.assertEqual(trace["spans"][2]["type"], "generation")
+
+
+# ======================================================================
+# LangfuseTracer (mocked)
+# ======================================================================
+
+
+def _make_langfuse_tracer():
+    """Create a LangfuseTracer with a mocked langfuse backend."""
+    from underthesea.agent.trace.langfuse_tracer import LangfuseTracer
+    mock_instance = MagicMock()
+    tracer = LangfuseTracer.__new__(LangfuseTracer)
+    tracer._langfuse = mock_instance
+    tracer._traces = {}
+    tracer._spans = {}
+    return tracer, mock_instance
+
+
+class TestLangfuseTracer(TestCase):
+    def test_start_end_trace(self):
+        tracer, mock_lf = _make_langfuse_tracer()
+        mock_lf.create_trace_id.return_value = "trace-123"
+
+        mock_obs = MagicMock()
+        mock_lf.start_observation.return_value = mock_obs
+
+        tid = tracer.start_trace(name="test", input="hello")
+        self.assertEqual(tid, "trace-123")
+        mock_lf.start_observation.assert_called_once()
+
+        tracer.end_trace(tid, output="world")
+        mock_obs.update.assert_called_once()
+        mock_obs.end.assert_called_once()
+        mock_lf.flush.assert_called_once()
+
+    def test_generation(self):
+        tracer, mock_lf = _make_langfuse_tracer()
+
+        mock_parent = MagicMock()
+        tracer._traces["trace-1"] = mock_parent
+
+        mock_gen = MagicMock()
+        mock_gen.id = "gen-1"
+        mock_parent.start_observation.return_value = mock_gen
+
+        sid = tracer.start_generation("trace-1", name="llm.chat", model="gpt-4")
+        self.assertEqual(sid, "gen-1")
+        mock_parent.start_observation.assert_called_once_with(
+            name="llm.chat", as_type="generation", input=None, model="gpt-4", metadata=None,
+        )
+
+        tracer.end_generation(
+            sid, output="response",
+            usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+        mock_gen.update.assert_called_once()
+        mock_gen.end.assert_called_once()
+        call_kwargs = mock_gen.update.call_args[1]
+        self.assertEqual(call_kwargs["usage_details"]["input"], 10)
+
+    def test_span(self):
+        tracer, mock_lf = _make_langfuse_tracer()
+
+        mock_parent = MagicMock()
+        tracer._traces["trace-1"] = mock_parent
+
+        mock_span = MagicMock()
+        mock_span.id = "span-1"
+        mock_parent.start_observation.return_value = mock_span
+
+        sid = tracer.start_span("trace-1", name="tool.calc", input={"x": 1})
+        self.assertEqual(sid, "span-1")
+        mock_parent.start_observation.assert_called_once_with(
+            name="tool.calc", as_type="tool", input={"x": 1}, metadata=None,
+        )
+
+        tracer.end_span(sid, output="2")
+        mock_span.update.assert_called_once()
+        mock_span.end.assert_called_once()
+
+    def test_unknown_trace_id_raises(self):
+        tracer, _ = _make_langfuse_tracer()
+        with self.assertRaises(ValueError):
+            tracer.start_generation("unknown", name="test")
+        with self.assertRaises(ValueError):
+            tracer.start_span("unknown", name="test")
+
+    def test_error_generation(self):
+        tracer, _ = _make_langfuse_tracer()
+        mock_parent = MagicMock()
+        tracer._traces["trace-1"] = mock_parent
+
+        mock_gen = MagicMock()
+        mock_gen.id = "gen-err"
+        mock_parent.start_observation.return_value = mock_gen
+
+        sid = tracer.start_generation("trace-1", name="llm.chat", model="gpt-4")
+        tracer.end_generation(sid, status="error", error="timeout")
+        call_kwargs = mock_gen.update.call_args[1]
+        self.assertEqual(call_kwargs["level"], "ERROR")
+
+    def test_flush_and_shutdown(self):
+        tracer, mock_lf = _make_langfuse_tracer()
+        tracer.flush()
+        mock_lf.flush.assert_called_once()
+        tracer.shutdown()
+        mock_lf.shutdown.assert_called_once()
+
+
+# ======================================================================
+# Agent integration with tracer
+# ======================================================================
+
+
+class TestAgentWithTracer(TestCase):
+    def setUp(self):
+        self.trace_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.trace_dir, ignore_errors=True)
+
+    def _make_tracer(self):
+        from underthesea.agent.trace.local import LocalTracer
+        return LocalTracer(trace_dir=self.trace_dir, console=False)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, return_value=_resp("Hello world!"))
+    def test_agent_class_with_tracer(self, mock_post):
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("test-bot", tracer=tracer)
+        result = bot("Hi")
+        self.assertEqual(result, "Hello world!")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        trace = traces[0]
+        self.assertEqual(trace["name"], "test-bot")
+        self.assertEqual(trace["input"], "Hi")
+        self.assertEqual(trace["output"], "Hello world!")
+        self.assertEqual(trace["status"], "ok")
+        # Should have one generation span
+        self.assertEqual(len(trace["spans"]), 1)
+        self.assertEqual(trace["spans"][0]["type"], "generation")
+        self.assertEqual(trace["spans"][0]["usage"]["input_tokens"], 100)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, side_effect=[
+        _tool_call_resp("calculator", {"expression": "2+2"}),
+        _resp("The answer is 4"),
+    ])
+    def test_agent_with_tools_and_tracer(self, mock_post):
+        from underthesea.agent import Agent, calculator_tool
+        tracer = self._make_tracer()
+        bot = Agent("calc-bot", tools=[calculator_tool], tracer=tracer)
+        result = bot("What is 2+2?")
+        self.assertEqual(result, "The answer is 4")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        trace = traces[0]
+        # 2 generations + 1 tool call = 3 spans
+        self.assertEqual(len(trace["spans"]), 3)
+        types = [s["type"] for s in trace["spans"]]
+        self.assertEqual(types, ["generation", "span", "generation"])
+        # Tool span
+        tool_span = trace["spans"][1]
+        self.assertEqual(tool_span["name"], "tool.calculator")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, side_effect=RuntimeError("API error"))
+    def test_agent_error_traced(self, mock_post):
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("error-bot", tracer=tracer)
+        with self.assertRaises(RuntimeError):
+            bot("fail")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        self.assertEqual(traces[0]["status"], "error")
+        self.assertIn("API error", traces[0]["error"])
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, return_value=_resp("Chao ban!"))
+    def test_agent_singleton_with_tracer(self, mock_post):
+        from underthesea import agent
+        agent.reset()
+        agent._llm = None
+        tracer = self._make_tracer()
+        result = agent("Xin chao", tracer=tracer)
+        self.assertEqual(result, "Chao ban!")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        self.assertEqual(traces[0]["input"], "Xin chao")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, return_value=_resp("No trace"))
+    def test_agent_without_tracer(self, mock_post):
+        """Agent should work normally when no tracer is set."""
+        from underthesea.agent import Agent
+        bot = Agent("no-trace")
+        result = bot("Hi")
+        self.assertEqual(result, "No trace")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, return_value=_resp("traced"))
+    def test_tracer_property(self, mock_post):
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("test", tracer=tracer)
+        self.assertIs(bot.tracer, tracer)
+
+        bot.tracer = None
+        self.assertIsNone(bot.tracer)
+
+
+# ======================================================================
+# @trace decorator
+# ======================================================================
+
+
+class TestTraceDecorator(TestCase):
+    def setUp(self):
+        self.trace_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.trace_dir, ignore_errors=True)
+
+    def _make_tracer(self):
+        from underthesea.agent.trace.local import LocalTracer
+        return LocalTracer(trace_dir=self.trace_dir, console=False)
+
+    def test_basic_decorator(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def greet(name: str) -> str:
+            return f"Hello {name}"
+
+        result = greet("World")
+        self.assertEqual(result, "Hello World")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        self.assertEqual(traces[0]["name"], "greet")
+        self.assertEqual(traces[0]["output"], "Hello World")
+        self.assertEqual(traces[0]["status"], "ok")
+
+    def test_custom_name(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer, name="my-custom-step")
+        def step():
+            return 42
+
+        step()
+        traces = tracer.list_traces()
+        self.assertEqual(traces[0]["name"], "my-custom-step")
+
+    def test_input_captured(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        add(3, 7)
+        traces = tracer.list_traces()
+        input_data = json.loads(traces[0]["input"])
+        self.assertEqual(input_data["a"], 3)
+        self.assertEqual(input_data["b"], 7)
+
+    def test_error_traced(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def fail():
+            raise ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            fail()
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        self.assertEqual(traces[0]["status"], "error")
+        self.assertIn("boom", traces[0]["error"])
+
+    def test_nested_creates_spans(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def inner_a(x):
+            return x * 2
+
+        @trace(tracer)
+        def inner_b(x):
+            return x + 1
+
+        @trace(tracer)
+        def outer(x):
+            a = inner_a(x)
+            b = inner_b(a)
+            return b
+
+        result = outer(5)
+        self.assertEqual(result, 11)  # (5*2)+1
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)  # Only one trace, not three
+        t = traces[0]
+        self.assertEqual(t["name"], "outer")
+        self.assertEqual(len(t["spans"]), 2)
+        self.assertEqual(t["spans"][0]["name"], "inner_a")
+        self.assertEqual(t["spans"][1]["name"], "inner_b")
+
+    def test_nested_error_in_span(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def bad_step():
+            raise RuntimeError("inner fail")
+
+        @trace(tracer)
+        def pipeline():
+            return bad_step()
+
+        with self.assertRaises(RuntimeError):
+            pipeline()
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        t = traces[0]
+        self.assertEqual(t["status"], "error")
+        self.assertEqual(len(t["spans"]), 1)
+        self.assertEqual(t["spans"][0]["status"], "error")
+        self.assertIn("inner fail", t["spans"][0]["error"])
+
+    def test_separate_calls_create_separate_traces(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def work(x):
+            return x
+
+        work(1)
+        work(2)
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 2)
+
+    def test_preserves_function_metadata(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def documented_func():
+            """This is my docstring."""
+            return True
+
+        self.assertEqual(documented_func.__name__, "documented_func")
+        self.assertEqual(documented_func.__doc__, "This is my docstring.")
+
+    def test_kwargs_captured(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def configure(host: str = "localhost", port: int = 8080):
+            return f"{host}:{port}"
+
+        configure(port=3000)
+        traces = tracer.list_traces()
+        input_data = json.loads(traces[0]["input"])
+        self.assertEqual(input_data["host"], "localhost")
+        self.assertEqual(input_data["port"], 3000)
+
+    def test_return_none(self):
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def noop():
+            pass
+
+        result = noop()
+        self.assertIsNone(result)
+        traces = tracer.list_traces()
+        self.assertEqual(traces[0]["output"], "None")
+
+
+# ======================================================================
+# Agent inherits @trace context (no explicit tracer)
+# ======================================================================
+
+
+class TestAgentInheritsTraceContext(TestCase):
+    def setUp(self):
+        self.trace_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.trace_dir, ignore_errors=True)
+
+    def _make_tracer(self):
+        from underthesea.agent.trace.local import LocalTracer
+        return LocalTracer(trace_dir=self.trace_dir, console=False)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, return_value=_resp("inherited!"))
+    def test_agent_inherits_trace_context(self, mock_post):
+        """Agent without explicit tracer should add spans to the @trace context."""
+        from underthesea.agent import Agent
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def pipeline(msg):
+            bot = Agent("inner-bot")  # no tracer set
+            return bot(msg)
+
+        result = pipeline("hello")
+        self.assertEqual(result, "inherited!")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        t = traces[0]
+        self.assertEqual(t["name"], "pipeline")
+        # Agent's LLM call should appear as a span
+        self.assertTrue(len(t["spans"]) >= 1)
+        gen_spans = [s for s in t["spans"] if s["type"] == "generation"]
+        self.assertTrue(len(gen_spans) >= 1)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, side_effect=[
+        _tool_call_resp("calculator", {"expression": "3+3"}),
+        _resp("The answer is 6"),
+    ])
+    def test_agent_with_tools_inherits_context(self, mock_post):
+        """Agent with tools should create tool + generation spans in @trace."""
+        from underthesea.agent import Agent, calculator_tool
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def pipeline(msg):
+            bot = Agent("calc-bot", tools=[calculator_tool])
+            return bot(msg)
+
+        result = pipeline("3+3?")
+        self.assertEqual(result, "The answer is 6")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        t = traces[0]
+        self.assertEqual(t["name"], "pipeline")
+        # 2 generations + 1 tool = 3 spans
+        self.assertEqual(len(t["spans"]), 3)
+        types = [s["type"] for s in t["spans"]]
+        self.assertEqual(types, ["generation", "span", "generation"])
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch(MOCK_POST, return_value=_resp("response"))
+    def test_agent_singleton_inherits_context(self, mock_post):
+        """The global `agent()` singleton also inherits @trace context."""
+        from underthesea import agent
+        from underthesea.agent.trace import trace
+        agent.reset()
+        agent._llm = None
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def pipeline(msg):
+            return agent(msg)
+
+        result = pipeline("hi")
+        self.assertEqual(result, "response")
+
+        traces = tracer.list_traces()
+        self.assertEqual(len(traces), 1)
+        t = traces[0]
+        self.assertEqual(t["name"], "pipeline")
+        gen_spans = [s for s in t["spans"] if s["type"] == "generation"]
+        self.assertTrue(len(gen_spans) >= 1)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "test-key",
+        "UNDERTHESEA_TRACE_DISABLED": "1",
+    })
+    @patch(MOCK_POST, return_value=_resp("no context"))
+    def test_agent_no_trace_when_disabled(self, mock_post):
+        """Agent with tracing disabled should not trace."""
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("solo")
+        result = bot("hi")
+        self.assertEqual(result, "no context")
+        self.assertEqual(len(tracer.list_traces()), 0)
+
+
+# ======================================================================
+# Env var toggle: UNDERTHESEA_TRACE_DISABLED
+# ======================================================================
+
+
+class TestTracingDisabledEnvVar(TestCase):
+    def setUp(self):
+        self.trace_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.trace_dir, ignore_errors=True)
+
+    def _make_tracer(self):
+        from underthesea.agent.trace.local import LocalTracer
+        return LocalTracer(trace_dir=self.trace_dir, console=False)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "UNDERTHESEA_TRACE_DISABLED": "1"})
+    @patch(MOCK_POST, return_value=_resp("no trace"))
+    def test_explicit_tracer_disabled_by_env(self, mock_post):
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("bot", tracer=tracer)
+        result = bot("hi")
+        self.assertEqual(result, "no trace")
+        self.assertEqual(len(tracer.list_traces()), 0)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "UNDERTHESEA_TRACE_DISABLED": "true"})
+    @patch(MOCK_POST, return_value=_resp("disabled"))
+    def test_env_var_true_string(self, mock_post):
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("bot", tracer=tracer)
+        bot("hi")
+        self.assertEqual(len(tracer.list_traces()), 0)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "UNDERTHESEA_TRACE_DISABLED": "0"})
+    @patch(MOCK_POST, return_value=_resp("enabled"))
+    def test_env_var_zero_means_enabled(self, mock_post):
+        from underthesea.agent import Agent
+        tracer = self._make_tracer()
+        bot = Agent("bot", tracer=tracer)
+        bot("hi")
+        self.assertEqual(len(tracer.list_traces()), 1)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "UNDERTHESEA_TRACE_DISABLED": "1"})
+    @patch(MOCK_POST, return_value=_resp("disabled"))
+    def test_decorator_disabled_by_env(self, mock_post):
+        """@trace decorator context should not propagate when disabled."""
+        from underthesea.agent import Agent
+        from underthesea.agent.trace import trace
+        tracer = self._make_tracer()
+
+        @trace(tracer)
+        def pipeline(msg):
+            bot = Agent("bot")
+            return bot(msg)
+
+        # The decorator itself still runs (it doesn't check env),
+        # but the Agent skips tracing
+        pipeline("hi")
+        traces = tracer.list_traces()
+        # Decorator creates a trace but Agent adds no spans
+        if traces:
+            agent_gens = [s for s in traces[0].get("spans", []) if s["type"] == "generation"]
+            self.assertEqual(len(agent_gens), 0)
+
+
+# ======================================================================
+# Auto local trace (like Claude Code)
+# ======================================================================
+
+
+class TestAutoTrace(TestCase):
+    def setUp(self):
+        self.trace_dir = tempfile.mkdtemp()
+        # Reset global auto tracer so each test gets a fresh one
+        import sys  # noqa: I001
+
+        import underthesea.agent  # noqa: F401 — ensure module is loaded
+        self._agent_mod = sys.modules["underthesea.agent.agent"]
+        self._orig_auto_tracer = self._agent_mod._auto_tracer
+        self._agent_mod._auto_tracer = None
+
+    def tearDown(self):
+        self._agent_mod._auto_tracer = self._orig_auto_tracer
+        shutil.rmtree(self.trace_dir, ignore_errors=True)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "test-key",
+        "UNDERTHESEA_TRACE_DIR": "",  # will be overridden below
+    })
+    @patch(MOCK_POST, return_value=_resp("auto traced!"))
+    def test_auto_trace_agent_class(self, mock_post):
+        """Agent without explicit tracer should auto-trace to local files."""
+        os.environ["UNDERTHESEA_TRACE_DIR"] = self.trace_dir
+        self._agent_mod._auto_tracer = None  # force re-creation with new dir
+
+        from underthesea.agent import Agent
+        bot = Agent("auto-bot")
+        result = bot("hello")
+        self.assertEqual(result, "auto traced!")
+
+        # Verify trace file was created in the auto directory
+        from underthesea.agent.trace.local import LocalTracer
+        reader = LocalTracer(trace_dir=self.trace_dir, console=False)
+        traces = reader.list_traces()
+        self.assertEqual(len(traces), 1)
+        self.assertEqual(traces[0]["name"], "auto-bot")
+        self.assertEqual(traces[0]["input"], "hello")
+        self.assertEqual(traces[0]["status"], "ok")
+        # Should have generation span
+        gen_spans = [s for s in traces[0]["spans"] if s["type"] == "generation"]
+        self.assertEqual(len(gen_spans), 1)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "test-key",
+        "UNDERTHESEA_TRACE_DIR": "",
+    })
+    @patch(MOCK_POST, return_value=_resp("auto singleton"))
+    def test_auto_trace_agent_singleton(self, mock_post):
+        """Global agent() singleton should auto-trace."""
+        os.environ["UNDERTHESEA_TRACE_DIR"] = self.trace_dir
+        self._agent_mod._auto_tracer = None
+
+        from underthesea import agent
+        agent.reset()
+        agent._llm = None
+        result = agent("hi")
+        self.assertEqual(result, "auto singleton")
+
+        from underthesea.agent.trace.local import LocalTracer
+        reader = LocalTracer(trace_dir=self.trace_dir, console=False)
+        traces = reader.list_traces()
+        self.assertEqual(len(traces), 1)
+        self.assertEqual(traces[0]["input"], "hi")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "test-key",
+        "UNDERTHESEA_TRACE_DIR": "",
+        "UNDERTHESEA_TRACE_DISABLED": "1",
+    })
+    @patch(MOCK_POST, return_value=_resp("no auto"))
+    def test_auto_trace_disabled_by_env(self, mock_post):
+        """Auto-trace should not run when UNDERTHESEA_TRACE_DISABLED=1."""
+        os.environ["UNDERTHESEA_TRACE_DIR"] = self.trace_dir
+        self._agent_mod._auto_tracer = None
+
+        from underthesea.agent import Agent
+        bot = Agent("bot")
+        result = bot("hi")
+        self.assertEqual(result, "no auto")
+
+        from underthesea.agent.trace.local import LocalTracer
+        reader = LocalTracer(trace_dir=self.trace_dir, console=False)
+        self.assertEqual(len(reader.list_traces()), 0)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "test-key",
+        "UNDERTHESEA_TRACE_DIR": "",
+    })
+    @patch(MOCK_POST, return_value=_resp("explicit wins"))
+    def test_explicit_tracer_overrides_auto(self, mock_post):
+        """Explicit tracer should be used instead of auto-tracer."""
+        os.environ["UNDERTHESEA_TRACE_DIR"] = self.trace_dir
+        self._agent_mod._auto_tracer = None
+
+        explicit_dir = tempfile.mkdtemp()
+        try:
+            from underthesea.agent import Agent
+            from underthesea.agent.trace.local import LocalTracer
+            explicit_tracer = LocalTracer(trace_dir=explicit_dir, console=False)
+            bot = Agent("bot", tracer=explicit_tracer)
+            bot("hi")
+
+            # Trace should be in explicit dir, not auto dir
+            self.assertEqual(len(explicit_tracer.list_traces()), 1)
+            auto_reader = LocalTracer(trace_dir=self.trace_dir, console=False)
+            self.assertEqual(len(auto_reader.list_traces()), 0)
+        finally:
+            shutil.rmtree(explicit_dir, ignore_errors=True)

--- a/underthesea/agent/__init__.py
+++ b/underthesea/agent/__init__.py
@@ -30,6 +30,7 @@ from underthesea.agent.providers import (
     ToolCall,
 )
 from underthesea.agent.tools import Tool
+from underthesea.agent.trace import BaseTracer, LangfuseTracer, LocalTracer
 
 __all__ = [
     # Core
@@ -47,6 +48,10 @@ __all__ = [
     "ProviderMessage",
     "StreamDelta",
     "ToolCall",
+    # Trace
+    "BaseTracer",
+    "LocalTracer",
+    "LangfuseTracer",
     # Tool collections
     "default_tools",
     "core_tools",

--- a/underthesea/agent/agent.py
+++ b/underthesea/agent/agent.py
@@ -1,8 +1,39 @@
 import json
+import os
 
 from underthesea.agent.llm import LLM
 from underthesea.agent.providers.base import BaseProvider
 from underthesea.agent.tools import Tool
+from underthesea.agent.trace.base import BaseTracer, extract_usage
+from underthesea.agent.trace.decorator import _current_trace_id, _current_tracer
+
+_auto_tracer = None
+
+
+def _tracing_disabled() -> bool:
+    """Check if tracing is disabled via environment variable."""
+    return os.environ.get("UNDERTHESEA_TRACE_DISABLED", "").lower() in ("1", "true", "yes")
+
+
+def _default_trace_dir() -> str:
+    """``~/.underthesea/traces`` — the default directory for auto-traces."""
+    return os.path.join(os.path.expanduser("~"), ".underthesea", "traces")
+
+
+def _get_auto_tracer() -> BaseTracer:
+    """Return a shared LocalTracer that writes to ``~/.underthesea/traces``.
+
+    Traces are saved automatically — like Claude Code — so every agent call
+    is recorded for later inspection.  Disable with
+    ``UNDERTHESEA_TRACE_DISABLED=1``, change the directory with
+    ``UNDERTHESEA_TRACE_DIR``.
+    """
+    global _auto_tracer
+    if _auto_tracer is None:
+        from underthesea.agent.trace.local import LocalTracer
+        trace_dir = os.environ.get("UNDERTHESEA_TRACE_DIR", _default_trace_dir())
+        _auto_tracer = LocalTracer(trace_dir=trace_dir, console=True)
+    return _auto_tracer
 
 
 class Agent:
@@ -17,6 +48,7 @@ class Agent:
         instruction: str | None = None,
         max_iterations: int = 10,
         provider: BaseProvider | LLM | None = None,
+        tracer: BaseTracer | None = None,
     ):
         """
         Initialize an Agent.
@@ -34,6 +66,10 @@ class Agent:
         provider : BaseProvider or LLM, optional
             LLM provider or LLM instance. If LLM is passed, its backend provider is used.
             If not specified, auto-detects from environment variables.
+        tracer : BaseTracer, optional
+            Tracer for observability (e.g. LocalTracer, LangfuseTracer).
+            If omitted, the agent inherits the active ``@trace()`` context
+            automatically.
         """
         self.name = name
         self.tools = tools or []
@@ -44,12 +80,43 @@ class Agent:
             self._provider = provider.backend
         else:
             self._provider = provider
+        self._tracer = tracer
         self._history: list[dict] = []
 
     def _ensure_provider(self, **kwargs):
         """Initialize provider if not already set."""
         if self._provider is None:
             self._provider = LLM(**kwargs).backend
+
+    def _resolve_tracing(self) -> tuple[BaseTracer | None, str | None, bool]:
+        """Resolve tracer and trace_id from explicit config, @trace context, or auto.
+
+        Resolution order:
+        1. Explicit ``tracer=`` on the Agent → creates its own trace
+        2. Active ``@trace()`` context      → attaches spans to existing trace
+        3. Auto local tracer                → creates its own trace (like Claude Code)
+
+        Disable everything with ``UNDERTHESEA_TRACE_DISABLED=1``.
+
+        Returns (tracer, trace_id, owns_trace).
+        - owns_trace=True  → caller must call end_trace()
+        - owns_trace=False → spans attach to an existing trace
+        """
+        if _tracing_disabled():
+            return None, None, False
+
+        # 1. Explicit tracer on the Agent → always creates its own trace
+        if self._tracer:
+            return self._tracer, None, True
+
+        # 2. Inherit from active @trace() context
+        ctx_tracer = _current_tracer.get()
+        ctx_trace_id = _current_trace_id.get()
+        if ctx_tracer and ctx_trace_id:
+            return ctx_tracer, ctx_trace_id, False
+
+        # 3. Auto local trace — every call is recorded by default
+        return _get_auto_tracer(), None, True
 
     def __call__(
         self,
@@ -77,25 +144,90 @@ class Agent:
         self._ensure_provider(**llm_kwargs)
         self._history.append({"role": "user", "content": message})
 
-        if self.tools:
-            return self._call_with_tools(model)
+        tracer, trace_id, owns_trace = self._resolve_tracing()
 
+        if tracer and owns_trace:
+            trace_id = tracer.start_trace(
+                name=self.name, input=message,
+                metadata={"model": model or getattr(self._provider, "default_model", None)},
+            )
+
+        try:
+            if self.tools:
+                response = self._call_with_tools(model, tracer=tracer, trace_id=trace_id)
+            else:
+                response = self._call_simple(model, tracer=tracer, trace_id=trace_id)
+
+            if tracer and owns_trace and trace_id:
+                tracer.end_trace(trace_id, output=response)
+            return response
+        except Exception as e:
+            if tracer and owns_trace and trace_id:
+                tracer.end_trace(trace_id, status="error", error=str(e))
+            raise
+
+    def _call_simple(
+        self, model: str | None,
+        tracer: BaseTracer | None = None, trace_id: str | None = None,
+    ) -> str:
+        """Handle message without tools."""
         messages = [{"role": "system", "content": self.instruction}] + self._history
+
+        span_id = None
+        if tracer and trace_id:
+            span_id = tracer.start_generation(
+                trace_id, name="llm.chat",
+                model=model or getattr(self._provider, "default_model", None),
+                input=messages,
+            )
+
         result = self._provider.chat(messages, model=model)
+
+        if tracer and span_id:
+            usage = extract_usage(result.raw) if hasattr(result, "raw") else None
+            tracer.end_generation(span_id, output=result.content, usage=usage)
+
         response = result.content
         self._history.append({"role": "assistant", "content": response})
         return response
 
-    def _call_with_tools(self, model: str | None) -> str:
+    def _call_with_tools(
+        self, model: str | None,
+        tracer: BaseTracer | None = None, trace_id: str | None = None,
+    ) -> str:
         """Handle message with tool calling loop."""
         messages = [{"role": "system", "content": self.instruction}] + self._history
         openai_tools = [t.to_openai_tool() for t in self.tools]
         tool_map = {t.name: t for t in self.tools}
+        gen_count = 0
 
         for _ in range(self.max_iterations):
+            gen_count += 1
+            resolved_model = model or getattr(self._provider, "default_model", None)
+
+            # -- trace: LLM generation --
+            span_id = None
+            if tracer and trace_id:
+                span_id = tracer.start_generation(
+                    trace_id, name=f"llm.chat #{gen_count}",
+                    model=resolved_model, input=messages,
+                )
+
             result = self._provider.chat(
                 messages, model=model, tools=openai_tools, tool_choice="auto"
             )
+
+            if tracer and span_id:
+                usage = extract_usage(result.raw) if hasattr(result, "raw") else None
+                gen_output = {
+                    "content": result.content,
+                    "tool_calls": (
+                        [{"name": tc.name, "arguments": tc.arguments}
+                         for tc in result.tool_calls]
+                        if result.tool_calls else None
+                    ),
+                }
+                tracer.end_generation(span_id, output=gen_output, usage=usage)
 
             if result.tool_calls:
                 assistant_msg = {"role": "assistant", "content": result.content}
@@ -111,7 +243,27 @@ class Agent:
 
                 for tc in result.tool_calls:
                     tool = tool_map[tc.name]
-                    tool_result = tool.execute(json.loads(tc.arguments))
+                    args = json.loads(tc.arguments)
+
+                    # -- trace: tool execution --
+                    tool_span_id = None
+                    if tracer and trace_id:
+                        tool_span_id = tracer.start_span(
+                            trace_id, name=f"tool.{tc.name}", input=args,
+                        )
+
+                    try:
+                        tool_result = tool.execute(args)
+                    except Exception as e:
+                        if tracer and tool_span_id:
+                            tracer.end_span(
+                                tool_span_id, status="error", error=str(e),
+                            )
+                        raise
+
+                    if tracer and tool_span_id:
+                        tracer.end_span(tool_span_id, output=tool_result)
+
                     messages.append({
                         "role": "tool",
                         "tool_call_id": tc.id,
@@ -143,13 +295,32 @@ class Agent:
         self._history.append({"role": "user", "content": message})
         messages = [{"role": "system", "content": self.instruction}] + self._history
 
+        tracer, trace_id, owns_trace = self._resolve_tracing()
+
+        if tracer and owns_trace:
+            trace_id = tracer.start_trace(name=self.name, input=message)
+
+        span_id = None
+        if tracer and trace_id:
+            span_id = tracer.start_generation(
+                trace_id, name="llm.chat_stream",
+                model=model or getattr(self._provider, "default_model", None),
+                input=messages,
+            )
+
         full_content = []
         for delta in self._provider.chat_stream(messages, model=model):
             if delta.content:
                 full_content.append(delta.content)
                 yield delta.content
 
-        self._history.append({"role": "assistant", "content": "".join(full_content)})
+        response = "".join(full_content)
+        self._history.append({"role": "assistant", "content": response})
+
+        if tracer and span_id:
+            tracer.end_generation(span_id, output=response)
+        if tracer and owns_trace and trace_id:
+            tracer.end_trace(trace_id, output=response)
 
     def reset(self):
         """Clear conversation history."""
@@ -159,6 +330,14 @@ class Agent:
     def history(self) -> list[dict]:
         """Get conversation history."""
         return self._history.copy()
+
+    @property
+    def tracer(self) -> BaseTracer | None:
+        return self._tracer
+
+    @tracer.setter
+    def tracer(self, value: BaseTracer | None):
+        self._tracer = value
 
 
 class _AgentInstance:
@@ -195,16 +374,61 @@ class _AgentInstance:
         api_key: str | None = None,
         azure_endpoint: str | None = None,
         azure_api_version: str | None = None,
+        tracer: BaseTracer | None = None,
     ) -> str:
         self._ensure_llm(provider, model, api_key, azure_endpoint, azure_api_version)
 
         if system_prompt:
             self._system_prompt = system_prompt
 
+        # Resolve tracer: explicit > context > auto
+        if _tracing_disabled():
+            tracer = None
+        elif tracer is None:
+            ctx_tracer = _current_tracer.get()
+            tracer = ctx_tracer if ctx_tracer else _get_auto_tracer()
+
         self._history.append({"role": "user", "content": message})
         messages = [{"role": "system", "content": self._system_prompt}] + self._history
 
-        assistant_message = self._llm.chat(messages, model=model)
+        trace_id = None
+        span_id = None
+        owns_trace = False
+        ctx_trace_id = _current_trace_id.get()
+
+        if tracer:
+            if ctx_trace_id:
+                # Inside @trace context → add spans to existing trace
+                trace_id = ctx_trace_id
+            else:
+                # Standalone / auto → create new trace
+                trace_id = tracer.start_trace(
+                    name="agent", input=message,
+                    metadata={
+                        "model": model or self._llm.model,
+                        "provider": self._llm.provider,
+                    },
+                )
+                owns_trace = True
+            span_id = tracer.start_generation(
+                trace_id, name="llm.chat",
+                model=model or self._llm.model, input=messages,
+            )
+
+        try:
+            assistant_message = self._llm.chat(messages, model=model)
+        except Exception as e:
+            if tracer and span_id:
+                tracer.end_generation(span_id, status="error", error=str(e))
+            if tracer and owns_trace and trace_id:
+                tracer.end_trace(trace_id, status="error", error=str(e))
+            raise
+
+        if tracer and span_id:
+            tracer.end_generation(span_id, output=assistant_message)
+        if tracer and owns_trace and trace_id:
+            tracer.end_trace(trace_id, output=assistant_message)
+
         self._history.append({"role": "assistant", "content": assistant_message})
         return assistant_message
 

--- a/underthesea/agent/trace/__init__.py
+++ b/underthesea/agent/trace/__init__.py
@@ -1,0 +1,12 @@
+from underthesea.agent.trace.base import BaseTracer, extract_usage
+from underthesea.agent.trace.decorator import trace
+from underthesea.agent.trace.langfuse_tracer import LangfuseTracer
+from underthesea.agent.trace.local import LocalTracer
+
+__all__ = [
+    "BaseTracer",
+    "LocalTracer",
+    "LangfuseTracer",
+    "extract_usage",
+    "trace",
+]

--- a/underthesea/agent/trace/base.py
+++ b/underthesea/agent/trace/base.py
@@ -1,0 +1,82 @@
+"""Base tracer interface for agent observability."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseTracer(ABC):
+    """Abstract base class for agent tracers.
+
+    Tracers capture the lifecycle of agent interactions:
+    trace (top-level) -> generation (LLM call) / span (tool call).
+    """
+
+    @abstractmethod
+    def start_trace(self, *, name: str, input: str, metadata: dict | None = None) -> str:
+        """Start a new trace. Returns trace_id."""
+
+    @abstractmethod
+    def end_trace(
+        self, trace_id: str, *, output: str | None = None,
+        status: str = "ok", error: str | None = None,
+    ):
+        """End a trace."""
+
+    @abstractmethod
+    def start_generation(
+        self, trace_id: str, *, name: str, model: str | None = None,
+        input: object = None, metadata: dict | None = None,
+    ) -> str:
+        """Start an LLM generation span. Returns span_id."""
+
+    @abstractmethod
+    def end_generation(
+        self, span_id: str, *, output: object = None,
+        usage: dict | None = None, status: str = "ok", error: str | None = None,
+    ):
+        """End an LLM generation span."""
+
+    @abstractmethod
+    def start_span(
+        self, trace_id: str, *, name: str,
+        input: object = None, metadata: dict | None = None,
+    ) -> str:
+        """Start a generic span (e.g. tool call). Returns span_id."""
+
+    @abstractmethod
+    def end_span(
+        self, span_id: str, *, output: object = None,
+        status: str = "ok", error: str | None = None,
+    ):
+        """End a generic span."""
+
+
+def extract_usage(raw: object) -> dict | None:
+    """Extract normalized token usage from a raw provider response.
+
+    Returns dict with keys: input_tokens, output_tokens, total_tokens.
+    """
+    if not raw or not isinstance(raw, dict):
+        return None
+    # OpenAI / Azure OpenAI
+    if "usage" in raw:
+        u = raw["usage"]
+        input_t = u.get("prompt_tokens") or u.get("input_tokens", 0)
+        output_t = u.get("completion_tokens") or u.get("output_tokens", 0)
+        return {
+            "input_tokens": input_t,
+            "output_tokens": output_t,
+            "total_tokens": u.get("total_tokens", input_t + output_t),
+        }
+    # Gemini
+    if "usageMetadata" in raw:
+        u = raw["usageMetadata"]
+        input_t = u.get("promptTokenCount", 0)
+        output_t = u.get("candidatesTokenCount", 0)
+        return {
+            "input_tokens": input_t,
+            "output_tokens": output_t,
+            "total_tokens": u.get("totalTokenCount", input_t + output_t),
+        }
+    return None

--- a/underthesea/agent/trace/decorator.py
+++ b/underthesea/agent/trace/decorator.py
@@ -1,0 +1,141 @@
+"""Decorator-based tracing for functions and methods."""
+
+from __future__ import annotations
+
+import contextvars
+import functools
+import inspect
+import json
+
+from underthesea.agent.trace.base import BaseTracer
+
+# Context variable to track the active trace — enables automatic nesting.
+_current_trace_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "trace_id", default=None
+)
+_current_tracer: contextvars.ContextVar[BaseTracer | None] = contextvars.ContextVar(
+    "tracer", default=None
+)
+
+
+def trace(tracer: BaseTracer, name: str | None = None):
+    """Decorator that traces a function call.
+
+    At the top level the decorator creates a **trace**.  When called inside
+    an already-traced function it creates a **span** (child) instead, so
+    nesting works automatically.
+
+    Parameters
+    ----------
+    tracer : BaseTracer
+        Tracer instance (``LocalTracer``, ``LangfuseTracer``, …).
+    name : str, optional
+        Override the span/trace name.  Defaults to ``func.__name__``.
+
+    Examples
+    --------
+    Simple — every call creates its own trace::
+
+        from underthesea.agent import LocalTracer
+        from underthesea.agent.trace import trace
+
+        tracer = LocalTracer()
+
+        @trace(tracer)
+        def greet(name: str) -> str:
+            return f"Hello {name}"
+
+        greet("World")
+
+    Nested — inner calls become spans of the outer trace::
+
+        @trace(tracer)
+        def pipeline(text):
+            cleaned = preprocess(text)
+            return classify(cleaned)
+
+        @trace(tracer)
+        def preprocess(text):
+            return text.strip().lower()
+
+        @trace(tracer)
+        def classify(text):
+            return "positive"
+
+        pipeline("  Hello!  ")
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            trace_name = name or func.__name__
+            input_data = _format_input(func, args, kwargs)
+            parent_trace_id = _current_trace_id.get()
+
+            if parent_trace_id is None:
+                # Top-level → new trace
+                trace_id = tracer.start_trace(name=trace_name, input=input_data)
+                token_tid = _current_trace_id.set(trace_id)
+                token_tr = _current_tracer.set(tracer)
+                try:
+                    result = func(*args, **kwargs)
+                    tracer.end_trace(trace_id, output=_safe_repr(result))
+                    return result
+                except Exception as e:
+                    tracer.end_trace(trace_id, status="error", error=str(e))
+                    raise
+                finally:
+                    _current_trace_id.reset(token_tid)
+                    _current_tracer.reset(token_tr)
+            else:
+                # Nested → span under the active trace
+                active_tracer = _current_tracer.get() or tracer
+                span_id = active_tracer.start_span(
+                    parent_trace_id, name=trace_name, input=input_data,
+                )
+                try:
+                    result = func(*args, **kwargs)
+                    active_tracer.end_span(span_id, output=_safe_repr(result))
+                    return result
+                except Exception as e:
+                    active_tracer.end_span(span_id, status="error", error=str(e))
+                    raise
+
+        return wrapper
+
+    return decorator
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _format_input(func, args, kwargs) -> str:
+    """Build a readable string from function arguments."""
+    try:
+        sig = inspect.signature(func)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        params = dict(bound.arguments)
+        # Remove 'self' / 'cls' for methods
+        params.pop("self", None)
+        params.pop("cls", None)
+        return json.dumps(params, ensure_ascii=False, default=str)
+    except Exception:
+        # Fallback: positional + keyword representation
+        parts = [repr(a) for a in args]
+        parts += [f"{k}={v!r}" for k, v in kwargs.items()]
+        return ", ".join(parts)
+
+
+def _safe_repr(obj) -> str:
+    """Convert a return value to a string, safely."""
+    if obj is None:
+        return "None"
+    if isinstance(obj, str):
+        return obj
+    try:
+        return json.dumps(obj, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return repr(obj)

--- a/underthesea/agent/trace/langfuse_tracer.py
+++ b/underthesea/agent/trace/langfuse_tracer.py
@@ -1,0 +1,180 @@
+"""Langfuse tracer — sends traces to Langfuse for remote observability.
+
+Compatible with Langfuse v4+ which uses the ``start_observation`` API.
+Observations are nested under a root agent span for proper hierarchy.
+"""
+
+from __future__ import annotations
+
+import os
+
+from underthesea.agent.trace.base import BaseTracer
+
+
+class LangfuseTracer(BaseTracer):
+    """Send agent traces to a Langfuse instance.
+
+    Requires the ``langfuse`` package (``pip install langfuse``).
+
+    Parameters
+    ----------
+    public_key : str, optional
+        Langfuse public key. Falls back to ``LANGFUSE_PUBLIC_KEY`` env var.
+    secret_key : str, optional
+        Langfuse secret key. Falls back to ``LANGFUSE_SECRET_KEY`` env var.
+    host : str, optional
+        Langfuse host URL. Falls back to ``LANGFUSE_HOST`` env var
+        (default ``https://cloud.langfuse.com``).
+
+    Examples
+    --------
+    >>> from underthesea.agent import Agent, LangfuseTracer
+    >>> tracer = LangfuseTracer()
+    >>> bot = Agent("demo", tracer=tracer)
+    >>> bot("Xin chao!")
+    """
+
+    def __init__(
+        self,
+        public_key: str | None = None,
+        secret_key: str | None = None,
+        host: str | None = None,
+    ):
+        try:
+            from langfuse import Langfuse  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "langfuse package is required for LangfuseTracer. "
+                "Install it with: pip install langfuse"
+            ) from None
+
+        self._langfuse = Langfuse(
+            public_key=public_key or os.environ.get("LANGFUSE_PUBLIC_KEY"),
+            secret_key=secret_key or os.environ.get("LANGFUSE_SECRET_KEY"),
+            host=host or os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com"),
+        )
+        # trace_id → root observation (as_type="agent")
+        self._traces: dict[str, object] = {}
+        # span_id → child observation
+        self._spans: dict[str, object] = {}
+
+    # ------------------------------------------------------------------
+    # BaseTracer implementation
+    # ------------------------------------------------------------------
+
+    def start_trace(self, *, name: str, input: str, metadata: dict | None = None) -> str:
+        trace_id = self._langfuse.create_trace_id()
+        obs = self._langfuse.start_observation(
+            trace_context={"trace_id": trace_id},
+            name=name,
+            as_type="agent",
+            input=input,
+            metadata=metadata,
+        )
+        self._traces[trace_id] = obs
+        return trace_id
+
+    def end_trace(
+        self, trace_id: str, *, output: str | None = None,
+        status: str = "ok", error: str | None = None,
+    ):
+        obs = self._traces.pop(trace_id, None)
+        if not obs:
+            return
+        update_kwargs: dict = {}
+        if output is not None:
+            update_kwargs["output"] = output
+        if error:
+            update_kwargs["level"] = "ERROR"
+            update_kwargs["status_message"] = f"{status}: {error}"
+        else:
+            update_kwargs["status_message"] = status
+        if update_kwargs:
+            obs.update(**update_kwargs)
+        obs.end()
+        self._langfuse.flush()
+
+    def start_generation(
+        self, trace_id: str, *, name: str, model: str | None = None,
+        input: object = None, metadata: dict | None = None,
+    ) -> str:
+        parent = self._traces.get(trace_id)
+        if not parent:
+            raise ValueError(f"Unknown trace_id: {trace_id}")
+        gen = parent.start_observation(
+            name=name,
+            as_type="generation",
+            input=input,
+            model=model,
+            metadata=metadata,
+        )
+        self._spans[gen.id] = gen
+        return gen.id
+
+    def end_generation(
+        self, span_id: str, *, output: object = None,
+        usage: dict | None = None, status: str = "ok", error: str | None = None,
+    ):
+        gen = self._spans.pop(span_id, None)
+        if not gen:
+            return
+        update_kwargs: dict = {}
+        if output is not None:
+            update_kwargs["output"] = output
+        if usage:
+            update_kwargs["usage_details"] = {
+                "input": usage.get("input_tokens", 0),
+                "output": usage.get("output_tokens", 0),
+                "total": usage.get("total_tokens", 0),
+            }
+        if error:
+            update_kwargs["level"] = "ERROR"
+            update_kwargs["status_message"] = f"error: {error}"
+        else:
+            update_kwargs["status_message"] = status
+        if update_kwargs:
+            gen.update(**update_kwargs)
+        gen.end()
+
+    def start_span(
+        self, trace_id: str, *, name: str,
+        input: object = None, metadata: dict | None = None,
+    ) -> str:
+        parent = self._traces.get(trace_id)
+        if not parent:
+            raise ValueError(f"Unknown trace_id: {trace_id}")
+        span = parent.start_observation(
+            name=name,
+            as_type="tool",
+            input=input,
+            metadata=metadata,
+        )
+        self._spans[span.id] = span
+        return span.id
+
+    def end_span(
+        self, span_id: str, *, output: object = None,
+        status: str = "ok", error: str | None = None,
+    ):
+        span = self._spans.pop(span_id, None)
+        if not span:
+            return
+        update_kwargs: dict = {}
+        if output is not None:
+            update_kwargs["output"] = output
+        if error:
+            update_kwargs["level"] = "ERROR"
+            update_kwargs["status_message"] = f"error: {error}"
+        else:
+            update_kwargs["status_message"] = status
+        if update_kwargs:
+            span.update(**update_kwargs)
+        span.end()
+
+    def flush(self):
+        """Flush pending events to Langfuse."""
+        self._langfuse.flush()
+
+    def shutdown(self):
+        """Shutdown the Langfuse client cleanly."""
+        self._langfuse.shutdown()

--- a/underthesea/agent/trace/local.py
+++ b/underthesea/agent/trace/local.py
@@ -1,0 +1,262 @@
+"""Local file-based tracer — saves traces as JSON for offline inspection."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+from underthesea.agent.trace.base import BaseTracer
+
+
+class LocalTracer(BaseTracer):
+    """Saves each agent call as a JSON trace file.
+
+    Parameters
+    ----------
+    trace_dir : str
+        Directory for trace files (created automatically). Default ``".traces"``.
+    console : bool
+        Print trace events to stderr/stdout while running. Default ``True``.
+
+    Examples
+    --------
+    >>> from underthesea.agent import Agent, LocalTracer, calculator_tool
+    >>> tracer = LocalTracer()
+    >>> bot = Agent("demo", tools=[calculator_tool], tracer=tracer)
+    >>> bot("What is 2+2?")
+    """
+
+    def __init__(self, trace_dir: str = ".traces", console: bool = True):
+        self._trace_dir = Path(trace_dir)
+        self._trace_dir.mkdir(parents=True, exist_ok=True)
+        self._console = console
+        # In-flight state
+        self._traces: dict[str, dict] = {}
+        self._spans: dict[str, dict] = {}
+
+    # ------------------------------------------------------------------
+    # BaseTracer implementation
+    # ------------------------------------------------------------------
+
+    def start_trace(self, *, name: str, input: str, metadata: dict | None = None) -> str:
+        trace_id = uuid4().hex[:12]
+        self._traces[trace_id] = {
+            "id": trace_id,
+            "name": name,
+            "input": input,
+            "start_time": _now(),
+            "spans": [],
+            "metadata": metadata or {},
+        }
+        if self._console:
+            _print(f">> Trace [{trace_id}] {name}")
+            _print(f"   Input: {_trunc(str(input))}")
+        return trace_id
+
+    def end_trace(
+        self, trace_id: str, *, output: str | None = None,
+        status: str = "ok", error: str | None = None,
+    ):
+        trace = self._traces.pop(trace_id, None)
+        if not trace:
+            return
+        trace["output"] = output
+        trace["end_time"] = _now()
+        trace["status"] = status
+        if error:
+            trace["error"] = error
+        trace["duration_ms"] = _duration_ms(trace["start_time"], trace["end_time"])
+
+        ts = datetime.fromisoformat(trace["start_time"]).strftime("%Y%m%d_%H%M%S")
+        filename = f"{ts}_trace_{trace_id}.json"
+        path = self._trace_dir / filename
+        with open(path, "w") as f:
+            json.dump(trace, f, indent=2, ensure_ascii=False, default=str)
+
+        if self._console:
+            icon = "[ok]" if status == "ok" else "[error]"
+            _print(f"<< Trace [{trace_id}] {icon} {trace['duration_ms']}ms -> {path}")
+
+    def start_generation(
+        self, trace_id: str, *, name: str, model: str | None = None,
+        input: object = None, metadata: dict | None = None,
+    ) -> str:
+        span_id = uuid4().hex[:12]
+        self._spans[span_id] = {
+            "id": span_id,
+            "trace_id": trace_id,
+            "name": name,
+            "type": "generation",
+            "model": model,
+            "input": input,
+            "start_time": _now(),
+            "metadata": metadata or {},
+        }
+        if self._console:
+            _print(f"   |-- Generation: {name} ({model or '?'})")
+        return span_id
+
+    def end_generation(
+        self, span_id: str, *, output: object = None,
+        usage: dict | None = None, status: str = "ok", error: str | None = None,
+    ):
+        span = self._spans.pop(span_id, None)
+        if not span:
+            return
+        span["output"] = output
+        span["end_time"] = _now()
+        span["status"] = status
+        span["duration_ms"] = _duration_ms(span["start_time"], span["end_time"])
+        if usage:
+            span["usage"] = usage
+        if error:
+            span["error"] = error
+
+        trace = self._traces.get(span["trace_id"])
+        if trace:
+            trace["spans"].append(span)
+
+        if self._console:
+            parts = [f"   |     {span['duration_ms']}ms"]
+            if usage:
+                parts.append(
+                    f" | {usage.get('input_tokens', '?')}->{usage.get('output_tokens', '?')} tokens"
+                )
+            if status != "ok":
+                parts.append(f" | {status}: {error or ''}")
+            _print("".join(parts))
+
+    def start_span(
+        self, trace_id: str, *, name: str,
+        input: object = None, metadata: dict | None = None,
+    ) -> str:
+        span_id = uuid4().hex[:12]
+        self._spans[span_id] = {
+            "id": span_id,
+            "trace_id": trace_id,
+            "name": name,
+            "type": "span",
+            "input": input,
+            "start_time": _now(),
+            "metadata": metadata or {},
+        }
+        if self._console:
+            _print(f"   |-- Tool: {name}")
+        return span_id
+
+    def end_span(
+        self, span_id: str, *, output: object = None,
+        status: str = "ok", error: str | None = None,
+    ):
+        span = self._spans.pop(span_id, None)
+        if not span:
+            return
+        span["output"] = output
+        span["end_time"] = _now()
+        span["status"] = status
+        span["duration_ms"] = _duration_ms(span["start_time"], span["end_time"])
+        if error:
+            span["error"] = error
+
+        trace = self._traces.get(span["trace_id"])
+        if trace:
+            trace["spans"].append(span)
+
+        if self._console:
+            result_str = _trunc(str(output), 80) if output else ""
+            _print(f"   |     {span['duration_ms']}ms | {result_str}")
+
+    # ------------------------------------------------------------------
+    # Utility: browse saved traces
+    # ------------------------------------------------------------------
+
+    def list_traces(self, limit: int = 20) -> list[dict]:
+        """List recent traces (newest first)."""
+        files = sorted(
+            self._trace_dir.glob("*_trace_*.json"),
+            key=os.path.getmtime,
+            reverse=True,
+        )
+        traces = []
+        for f in files[:limit]:
+            with open(f) as fh:
+                traces.append(json.load(fh))
+        return traces
+
+    def get_trace(self, trace_id: str) -> dict | None:
+        """Load a single trace by ID."""
+        matches = list(self._trace_dir.glob(f"*_trace_{trace_id}.json"))
+        if matches:
+            with open(matches[0]) as f:
+                return json.load(f)
+        return None
+
+    def print_trace(self, trace: dict | str):
+        """Pretty-print a trace to the console."""
+        if isinstance(trace, str):
+            trace = self.get_trace(trace)
+        if not trace:
+            print("Trace not found.")
+            return
+
+        w = 60
+        print(f"\n{'=' * w}")
+        print(f"Trace: {trace['name']} [{trace['id']}]")
+        print(f"Status: {trace['status']} | Duration: {trace.get('duration_ms', '?')}ms")
+        print(f"Time: {trace['start_time']}")
+        print(f"{'-' * w}")
+        print(f"Input: {trace['input']}")
+        print(f"{'-' * w}")
+
+        spans = trace.get("spans", [])
+        for i, span in enumerate(spans):
+            is_last = i == len(spans) - 1
+            prefix = "`--" if is_last else "|--"
+            tag = "[LLM]" if span["type"] == "generation" else "[Tool]"
+
+            print(f"{prefix} {tag} {span['name']} ({span.get('duration_ms', '?')}ms)")
+
+            indent = "    " if is_last else "|   "
+            if span["type"] == "generation":
+                if span.get("model"):
+                    print(f"{indent}Model: {span['model']}")
+                usage = span.get("usage")
+                if usage:
+                    print(
+                        f"{indent}Tokens: {usage.get('input_tokens', '?')} in"
+                        f" -> {usage.get('output_tokens', '?')} out"
+                    )
+            else:
+                if span.get("input"):
+                    print(f"{indent}Input: {_trunc(str(span['input']), 100)}")
+                if span.get("output"):
+                    print(f"{indent}Output: {_trunc(str(span['output']), 100)}")
+
+        print(f"{'-' * w}")
+        print(f"Output: {_trunc(str(trace.get('output', '')), 200)}")
+        print(f"{'=' * w}\n")
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _now() -> str:
+    return datetime.now().isoformat()
+
+
+def _duration_ms(start: str, end: str) -> int:
+    s = datetime.fromisoformat(start)
+    e = datetime.fromisoformat(end)
+    return int((e - s).total_seconds() * 1000)
+
+
+def _trunc(s: str, max_len: int = 120) -> str:
+    return s[:max_len] + "..." if len(s) > max_len else s
+
+
+def _print(msg: str):
+    print(msg)


### PR DESCRIPTION
## Summary
- Add `underthesea.agent.trace` module with `LocalTracer` (auto-saves JSON to `~/.underthesea/traces/`), `LangfuseTracer` (Langfuse v4 API), and `@trace` decorator with `contextvars` nesting
- Agent auto-traces by default (like Claude Code), disable with `UNDERTHESEA_TRACE_DISABLED=1`
- Agent inherits `@trace()` context automatically — no need to pass tracer explicitly when wrapped in a decorated function

## Test plan
- [x] 48 unit tests covering LocalTracer, LangfuseTracer (mocked), decorator, Agent integration, context inheritance, env var toggle, auto-trace
- [x] E2E tested with Azure OpenAI (gpt-4.1-mini) — 4-turn chat with tool calls
- [x] Verified Langfuse traces appear on cloud.langfuse.com with correct hierarchy, token usage, and cost
- [x] Lint clean (ruff)
- [x] No regressions on existing agent tests (35 tests)