### PR TITLE
feat(agent): parallel tool calls, tool error recovery, @tool decorator, retry & usage tracking

### DIFF
--- a/tests/agent/test_enhancements.py
+++ b/tests/agent/test_enhancements.py
@@ -1,0 +1,463 @@
+"""Tests for the v9.4+ agent enhancements:
+
+- Parallel tool execution
+- Tool error recovery (errors fed back to the model)
+- Token usage tracking on the Agent
+- ``@tool`` decorator and richer Tool schema extraction
+- HTTP retry with exponential backoff
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Literal, Optional
+from unittest import TestCase
+from unittest.mock import patch
+
+MOCK_POST = "underthesea.agent.providers._http.post_json"
+
+
+def _resp(content="Hello!", *, usage=None):
+    data = {"choices": [{"message": {"role": "assistant", "content": content}, "finish_reason": "stop"}]}
+    if usage is not None:
+        data["usage"] = usage
+    return data
+
+
+def _tool_call_resp(calls, *, usage=None):
+    msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": tc["id"],
+                "type": "function",
+                "function": {"name": tc["name"], "arguments": tc["arguments"]},
+            }
+            for tc in calls
+        ],
+    }
+    data = {"choices": [{"message": msg, "finish_reason": "tool_calls"}]}
+    if usage is not None:
+        data["usage"] = usage
+    return data
+
+
+# ---------------------------------------------------------------------------
+# @tool decorator + Tool schema enhancements
+# ---------------------------------------------------------------------------
+
+
+class TestToolDecorator(TestCase):
+    def test_bare_decorator(self):
+        from underthesea.agent import Tool, tool
+
+        @tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        self.assertIsInstance(add, Tool)
+        self.assertEqual(add.name, "add")
+        self.assertEqual(add.description, "Add two numbers.")
+        self.assertEqual(add(a=2, b=3), 5)
+
+    def test_decorator_with_overrides(self):
+        from underthesea.agent import tool
+
+        @tool(name="adder", description="Sum two ints")
+        def _impl(a: int, b: int) -> int:
+            return a + b
+
+        self.assertEqual(_impl.name, "adder")
+        self.assertEqual(_impl.description, "Sum two ints")
+
+
+class TestToolSchema(TestCase):
+    def test_optional_type(self):
+        from underthesea.agent import Tool
+
+        def func(name: str, age: Optional[int] = None) -> dict:
+            return {"name": name, "age": age}
+
+        schema = Tool(func).parameters
+        self.assertEqual(schema["properties"]["age"]["type"], "integer")
+        self.assertNotIn("age", schema["required"])
+        self.assertIn("name", schema["required"])
+
+    def test_list_with_item_type(self):
+        from underthesea.agent import Tool
+
+        def func(tags: list[str]) -> int:
+            return len(tags)
+
+        schema = Tool(func).parameters
+        self.assertEqual(schema["properties"]["tags"]["type"], "array")
+        self.assertEqual(schema["properties"]["tags"]["items"], {"type": "string"})
+
+    def test_dict_with_value_type(self):
+        from underthesea.agent import Tool
+
+        def func(counts: dict[str, int]) -> int:
+            return sum(counts.values())
+
+        schema = Tool(func).parameters
+        prop = schema["properties"]["counts"]
+        self.assertEqual(prop["type"], "object")
+        self.assertEqual(prop["additionalProperties"], {"type": "integer"})
+
+    def test_literal_becomes_enum(self):
+        from underthesea.agent import Tool
+
+        def func(mode: Literal["fast", "slow"]) -> str:
+            return mode
+
+        schema = Tool(func).parameters
+        prop = schema["properties"]["mode"]
+        self.assertEqual(prop["type"], "string")
+        self.assertEqual(prop["enum"], ["fast", "slow"])
+
+    def test_param_descriptions_parsed_from_docstring(self):
+        from underthesea.agent import Tool
+
+        def func(city: str, units: str = "metric") -> dict:
+            """Get the weather forecast.
+
+            Args:
+                city: City to look up.
+                units: Units system (metric or imperial).
+            """
+            return {}
+
+        schema = Tool(func).parameters
+        self.assertEqual(schema["properties"]["city"]["description"], "City to look up.")
+        self.assertEqual(
+            schema["properties"]["units"]["description"],
+            "Units system (metric or imperial).",
+        )
+
+    def test_default_value_recorded(self):
+        from underthesea.agent import Tool
+
+        def func(lang: str = "vi") -> str:
+            return lang
+
+        schema = Tool(func).parameters
+        self.assertEqual(schema["properties"]["lang"]["default"], "vi")
+        self.assertNotIn("lang", schema["required"])
+
+
+# ---------------------------------------------------------------------------
+# Parallel tool execution
+# ---------------------------------------------------------------------------
+
+
+class TestParallelToolExecution(TestCase):
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_parallel_tools_run_concurrently(self):
+        from underthesea.agent import Agent, Tool
+
+        barrier = threading.Barrier(2, timeout=5)
+
+        def slow_a() -> str:
+            barrier.wait()
+            return "a"
+
+        def slow_b() -> str:
+            barrier.wait()
+            return "b"
+
+        agent = Agent(
+            name="t",
+            tools=[Tool(slow_a, name="slow_a"), Tool(slow_b, name="slow_b")],
+            parallel_tools=True,
+        )
+
+        side = [
+            _tool_call_resp([
+                {"id": "1", "name": "slow_a", "arguments": "{}"},
+                {"id": "2", "name": "slow_b", "arguments": "{}"},
+            ]),
+            _resp("done"),
+        ]
+
+        with patch(MOCK_POST, side_effect=side):
+            result = agent("Go")
+        # If execution were sequential, the barrier would deadlock and time out.
+        self.assertEqual(result, "done")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_sequential_when_disabled(self):
+        from underthesea.agent import Agent, Tool
+
+        calls: list[str] = []
+
+        def record(name: str) -> str:
+            calls.append(name)
+            return name
+
+        agent = Agent(
+            name="t",
+            tools=[Tool(record)],
+            parallel_tools=False,
+        )
+
+        side = [
+            _tool_call_resp([
+                {"id": "1", "name": "record", "arguments": '{"name": "a"}'},
+                {"id": "2", "name": "record", "arguments": '{"name": "b"}'},
+            ]),
+            _resp("done"),
+        ]
+
+        with patch(MOCK_POST, side_effect=side):
+            agent("Go")
+        self.assertEqual(calls, ["a", "b"])
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_tool_results_order_preserved(self):
+        from underthesea.agent import Agent, Tool
+
+        def echo(text: str) -> str:
+            # Vary the sleep so a, b, c return out of order if parallel.
+            delays = {"a": 0.02, "b": 0.0, "c": 0.01}
+            time.sleep(delays.get(text, 0))
+            return text
+
+        agent = Agent(name="t", tools=[Tool(echo)], parallel_tools=True)
+        captured: list[list[dict]] = []
+
+        def fake_post(url, headers, body, **kw):
+            captured.append(body["messages"])
+            if len(captured) == 1:
+                return _tool_call_resp([
+                    {"id": "1", "name": "echo", "arguments": '{"text": "a"}'},
+                    {"id": "2", "name": "echo", "arguments": '{"text": "b"}'},
+                    {"id": "3", "name": "echo", "arguments": '{"text": "c"}'},
+                ])
+            return _resp("ok")
+
+        with patch(MOCK_POST, side_effect=fake_post):
+            agent("Go")
+        second_call_msgs = captured[1]
+        tool_msgs = [m for m in second_call_msgs if m.get("role") == "tool"]
+        self.assertEqual([m["tool_call_id"] for m in tool_msgs], ["1", "2", "3"])
+
+
+# ---------------------------------------------------------------------------
+# Tool error recovery
+# ---------------------------------------------------------------------------
+
+
+class TestToolErrorRecovery(TestCase):
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_recover_default_feeds_error_back(self):
+        from underthesea.agent import Agent, Tool
+
+        def fail() -> str:
+            raise RuntimeError("boom")
+
+        agent = Agent(name="t", tools=[Tool(fail)])
+        sent_messages: list[list[dict]] = []
+
+        def fake_post(url, headers, body, **kw):
+            sent_messages.append(body["messages"])
+            if len(sent_messages) == 1:
+                return _tool_call_resp([{"id": "1", "name": "fail", "arguments": "{}"}])
+            return _resp("Sorry, the tool failed.")
+
+        with patch(MOCK_POST, side_effect=fake_post):
+            response = agent("Run it")
+
+        self.assertEqual(response, "Sorry, the tool failed.")
+        tool_msgs = [m for m in sent_messages[1] if m.get("role") == "tool"]
+        self.assertEqual(len(tool_msgs), 1)
+        self.assertIn("boom", tool_msgs[0]["content"])
+        self.assertIn("error", tool_msgs[0]["content"])
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_raise_mode_propagates(self):
+        from underthesea.agent import Agent, Tool
+
+        def fail() -> str:
+            raise RuntimeError("boom")
+
+        agent = Agent(
+            name="t",
+            tools=[Tool(fail)],
+            tool_error_handling="raise",
+        )
+
+        with patch(MOCK_POST, return_value=_tool_call_resp(
+            [{"id": "1", "name": "fail", "arguments": "{}"}]
+        )):
+            with self.assertRaises(RuntimeError) as ctx:
+                agent("Run it")
+        self.assertIn("boom", str(ctx.exception))
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_invalid_arguments_recovered(self):
+        from underthesea.agent import Agent, Tool
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        agent = Agent(name="t", tools=[Tool(add)])
+
+        side = [
+            _tool_call_resp([{"id": "1", "name": "add", "arguments": "not-json"}]),
+            _resp("got it"),
+        ]
+        with patch(MOCK_POST, side_effect=side):
+            response = agent("compute")
+        self.assertEqual(response, "got it")
+
+    def test_invalid_tool_error_handling_rejected(self):
+        from underthesea.agent import Agent
+        with self.assertRaises(ValueError):
+            Agent(name="t", tool_error_handling="ignore")
+
+
+# ---------------------------------------------------------------------------
+# Token usage tracking
+# ---------------------------------------------------------------------------
+
+
+class TestUsageTracking(TestCase):
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_usage_tracked_for_simple_call(self):
+        from underthesea.agent import Agent
+
+        agent = Agent(name="t")
+        usage = {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17}
+
+        with patch(MOCK_POST, return_value=_resp("hi", usage=usage)):
+            agent("Hello")
+
+        self.assertEqual(agent.last_usage["input_tokens"], 10)
+        self.assertEqual(agent.last_usage["output_tokens"], 7)
+        self.assertEqual(agent.last_usage["total_tokens"], 17)
+        self.assertEqual(agent.total_usage["total_tokens"], 17)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_usage_accumulates_across_tool_iterations(self):
+        from underthesea.agent import Agent, Tool
+
+        agent = Agent(name="t", tools=[Tool(lambda: "x", name="x")])
+        usage = {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+
+        side = [
+            _tool_call_resp([{"id": "1", "name": "x", "arguments": "{}"}], usage=usage),
+            _resp("done", usage=usage),
+        ]
+        with patch(MOCK_POST, side_effect=side):
+            agent("Go")
+
+        self.assertEqual(agent.last_usage["total_tokens"], 16)
+        self.assertEqual(agent.total_usage["total_tokens"], 16)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_last_usage_resets_per_call_but_total_keeps_growing(self):
+        from underthesea.agent import Agent
+
+        agent = Agent(name="t")
+        usage = {"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5}
+
+        with patch(MOCK_POST, return_value=_resp("a", usage=usage)):
+            agent("First")
+            agent("Second")
+
+        self.assertEqual(agent.last_usage["total_tokens"], 5)
+        self.assertEqual(agent.total_usage["total_tokens"], 10)
+
+
+# ---------------------------------------------------------------------------
+# HTTP retry with exponential backoff
+# ---------------------------------------------------------------------------
+
+
+class TestHttpRetry(TestCase):
+    def test_retries_on_5xx(self):
+        import urllib.error
+        from io import BytesIO
+
+        from underthesea.agent.providers import _http
+
+        attempts: list[int] = []
+
+        def fake_urlopen(req, timeout=None):
+            attempts.append(1)
+            if len(attempts) < 3:
+                err = urllib.error.HTTPError(
+                    url=req.full_url, code=503, msg="busy",
+                    hdrs=None, fp=BytesIO(b"upstream busy"),
+                )
+                raise err
+
+            class _OK:
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, *a):
+                    return False
+
+                def read(self_inner):
+                    return b'{"ok": true}'
+
+            return _OK()
+
+        with patch.object(_http.urllib.request, "urlopen", side_effect=fake_urlopen), \
+                patch.object(_http.time, "sleep") as mock_sleep:
+            result = _http.post_json(
+                "http://x", {}, {}, max_retries=3, base_delay=0.0, max_delay=0.0,
+            )
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(len(attempts), 3)
+        # Slept twice (between attempts 1->2 and 2->3).
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    def test_does_not_retry_on_4xx(self):
+        import urllib.error
+        from io import BytesIO
+
+        from underthesea.agent.providers import _http
+        from underthesea.agent.providers._http import LLMError
+
+        attempts: list[int] = []
+
+        def fake_urlopen(req, timeout=None):
+            attempts.append(1)
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=401, msg="unauth",
+                hdrs=None, fp=BytesIO(b"bad key"),
+            )
+
+        with patch.object(_http.urllib.request, "urlopen", side_effect=fake_urlopen), \
+                patch.object(_http.time, "sleep"):
+            with self.assertRaises(LLMError) as ctx:
+                _http.post_json("http://x", {}, {}, max_retries=3, base_delay=0.0)
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(len(attempts), 1)
+
+    def test_gives_up_after_max_retries(self):
+        import urllib.error
+        from io import BytesIO
+
+        from underthesea.agent.providers import _http
+        from underthesea.agent.providers._http import LLMError
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                url=req.full_url, code=503, msg="busy",
+                hdrs=None, fp=BytesIO(b"still busy"),
+            )
+
+        with patch.object(_http.urllib.request, "urlopen", side_effect=fake_urlopen), \
+                patch.object(_http.time, "sleep"):
+            with self.assertRaises(LLMError):
+                _http.post_json(
+                    "http://x", {}, {}, max_retries=2, base_delay=0.0, max_delay=0.0,
+                )

--- a/underthesea/agent/__init__.py
+++ b/underthesea/agent/__init__.py
@@ -30,7 +30,7 @@ from underthesea.agent.providers import (
     StreamDelta,
     ToolCall,
 )
-from underthesea.agent.tools import Tool
+from underthesea.agent.tools import Tool, tool
 from underthesea.agent.trace import BaseTracer, LangfuseTracer, LocalTracer
 
 __all__ = [
@@ -41,6 +41,7 @@ __all__ = [
     "LLM",
     "Session",
     "Tool",
+    "tool",
     # Providers
     "OpenAI",
     "AzureOpenAI",

--- a/underthesea/agent/__init__.py
+++ b/underthesea/agent/__init__.py
@@ -1,5 +1,4 @@
 from underthesea.agent.agent import Agent, agent
-from underthesea.agent.wiki import WikiAgent
 from underthesea.agent.default_tools import (
     calculator_tool,
     core_tools,
@@ -32,6 +31,7 @@ from underthesea.agent.providers import (
 )
 from underthesea.agent.tools import Tool, tool
 from underthesea.agent.trace import BaseTracer, LangfuseTracer, LocalTracer
+from underthesea.agent.wiki import WikiAgent
 
 __all__ = [
     # Core

--- a/underthesea/agent/agent.py
+++ b/underthesea/agent/agent.py
@@ -1,5 +1,6 @@
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 from underthesea.agent.llm import LLM
 from underthesea.agent.providers.base import BaseProvider
@@ -8,6 +9,23 @@ from underthesea.agent.trace.base import BaseTracer, extract_usage
 from underthesea.agent.trace.decorator import _current_trace_id, _current_tracer
 
 _auto_tracer = None
+
+
+def _empty_usage() -> dict[str, int]:
+    return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def _safe_load_args(raw: str) -> tuple[dict, str | None]:
+    """Parse a JSON-encoded tool-arguments blob, tolerating empty strings."""
+    if not raw:
+        return {}, None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as e:
+        return {}, str(e)
+    if not isinstance(parsed, dict):
+        return {}, f"Tool arguments must decode to an object, got {type(parsed).__name__}"
+    return parsed, None
 
 
 def _tracing_disabled() -> bool:
@@ -49,6 +67,9 @@ class Agent:
         max_iterations: int = 10,
         provider: BaseProvider | LLM | None = None,
         tracer: BaseTracer | None = None,
+        parallel_tools: bool = True,
+        max_tool_workers: int = 8,
+        tool_error_handling: str = "recover",
     ):
         """
         Initialize an Agent.
@@ -70,11 +91,28 @@ class Agent:
             Tracer for observability (e.g. LocalTracer, LangfuseTracer).
             If omitted, the agent inherits the active ``@trace()`` context
             automatically.
+        parallel_tools : bool
+            When the model returns multiple tool calls in one response, execute
+            them concurrently in a thread pool.  Set to ``False`` to keep
+            sequential execution (useful when tools share mutable state).
+        max_tool_workers : int
+            Upper bound on threads used for parallel tool execution.
+        tool_error_handling : {"recover", "raise"}
+            ``"recover"`` (default) catches tool exceptions and feeds the error
+            back to the model as the tool result, so the agent can self-correct.
+            ``"raise"`` propagates the original behaviour of aborting the run.
         """
+        if tool_error_handling not in ("recover", "raise"):
+            raise ValueError(
+                f"tool_error_handling must be 'recover' or 'raise', got {tool_error_handling!r}",
+            )
         self.name = name
         self.tools = tools or []
         self.instruction = instruction or self.DEFAULT_INSTRUCTION
         self.max_iterations = max_iterations
+        self.parallel_tools = parallel_tools
+        self.max_tool_workers = max_tool_workers
+        self.tool_error_handling = tool_error_handling
         # Accept LLM (auto-detect) or any BaseProvider
         if isinstance(provider, LLM):
             self._provider = provider.backend
@@ -82,6 +120,8 @@ class Agent:
             self._provider = provider
         self._tracer = tracer
         self._history: list[dict] = []
+        self._last_usage: dict[str, int] = _empty_usage()
+        self._total_usage: dict[str, int] = _empty_usage()
 
     def _ensure_provider(self, **kwargs):
         """Initialize provider if not already set."""
@@ -143,6 +183,7 @@ class Agent:
         """
         self._ensure_provider(**llm_kwargs)
         self._history.append({"role": "user", "content": message})
+        self._last_usage = _empty_usage()
 
         tracer, trace_id, owns_trace = self._resolve_tracing()
 
@@ -183,8 +224,9 @@ class Agent:
 
         result = self._provider.chat(messages, model=model)
 
+        usage = extract_usage(result.raw) if hasattr(result, "raw") else None
+        self._accumulate_usage(usage)
         if tracer and span_id:
-            usage = extract_usage(result.raw) if hasattr(result, "raw") else None
             tracer.end_generation(span_id, output=result.content, usage=usage)
 
         response = result.content
@@ -217,8 +259,9 @@ class Agent:
                 messages, model=model, tools=openai_tools, tool_choice="auto"
             )
 
+            usage = extract_usage(result.raw) if hasattr(result, "raw") else None
+            self._accumulate_usage(usage)
             if tracer and span_id:
-                usage = extract_usage(result.raw) if hasattr(result, "raw") else None
                 gen_output = {
                     "content": result.content,
                     "tool_calls": (
@@ -241,40 +284,100 @@ class Agent:
                 ]
                 messages.append(assistant_msg)
 
-                for tc in result.tool_calls:
-                    tool = tool_map[tc.name]
-                    args = json.loads(tc.arguments)
-
-                    # -- trace: tool execution --
-                    tool_span_id = None
-                    if tracer and trace_id:
-                        tool_span_id = tracer.start_span(
-                            trace_id, name=f"tool.{tc.name}", input=args,
-                        )
-
-                    try:
-                        tool_result = tool.execute(args)
-                    except Exception as e:
-                        if tracer and tool_span_id:
-                            tracer.end_span(
-                                tool_span_id, status="error", error=str(e),
-                            )
-                        raise
-
-                    if tracer and tool_span_id:
-                        tracer.end_span(tool_span_id, output=tool_result)
-
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": tool_result,
-                    })
+                tool_messages = self._run_tool_calls(
+                    result.tool_calls, tool_map, tracer, trace_id,
+                )
+                messages.extend(tool_messages)
             else:
                 content = result.content
                 self._history.append({"role": "assistant", "content": content})
                 return content
 
         raise RuntimeError("Max tool iterations reached")
+
+    def _run_tool_calls(
+        self,
+        tool_calls,
+        tool_map: dict[str, Tool],
+        tracer: BaseTracer | None,
+        trace_id: str | None,
+    ) -> list[dict]:
+        """Execute a batch of tool calls and return the resulting tool messages.
+
+        Calls run concurrently in a thread pool when ``parallel_tools`` is set
+        and there is more than one call.  Order is preserved so the model sees
+        results in the same order it requested them.
+        """
+        if not tool_calls:
+            return []
+
+        run_one = self._run_single_tool
+
+        if self.parallel_tools and len(tool_calls) > 1:
+            workers = min(self.max_tool_workers, len(tool_calls))
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                results = list(executor.map(
+                    lambda tc: run_one(tc, tool_map, tracer, trace_id),
+                    tool_calls,
+                ))
+        else:
+            results = [run_one(tc, tool_map, tracer, trace_id) for tc in tool_calls]
+        return results
+
+    def _run_single_tool(
+        self,
+        tc,
+        tool_map: dict[str, Tool],
+        tracer: BaseTracer | None,
+        trace_id: str | None,
+    ) -> dict:
+        """Run one tool call and return the matching ``role=tool`` message.
+
+        Errors are JSON-encoded and surfaced to the model unless the agent is
+        configured with ``tool_error_handling="raise"``.
+        """
+        args, parse_error = _safe_load_args(tc.arguments)
+
+        tool_span_id = None
+        if tracer and trace_id:
+            tool_span_id = tracer.start_span(
+                trace_id, name=f"tool.{tc.name}", input=args,
+            )
+
+        try:
+            if parse_error is not None:
+                raise ValueError(f"Invalid tool arguments JSON: {parse_error}")
+            tool = tool_map.get(tc.name)
+            if tool is None:
+                raise KeyError(f"Unknown tool: {tc.name!r}")
+            tool_result = tool.execute(args)
+        except Exception as e:
+            if tracer and tool_span_id:
+                tracer.end_span(tool_span_id, status="error", error=str(e))
+            if self.tool_error_handling == "raise":
+                raise
+            tool_result = json.dumps(
+                {"error": str(e), "tool": tc.name},
+                ensure_ascii=False,
+            )
+        else:
+            if tracer and tool_span_id:
+                tracer.end_span(tool_span_id, output=tool_result)
+
+        return {
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": tool_result,
+        }
+
+    def _accumulate_usage(self, usage: dict | None) -> None:
+        """Track per-call and lifetime token usage on the agent."""
+        if not usage:
+            return
+        for key in ("input_tokens", "output_tokens", "total_tokens"):
+            value = usage.get(key, 0) or 0
+            self._last_usage[key] = self._last_usage.get(key, 0) + value
+            self._total_usage[key] = self._total_usage.get(key, 0) + value
 
     def stream(self, message: str, model: str | None = None, **llm_kwargs):
         """Stream a response, yielding text chunks.
@@ -323,8 +426,9 @@ class Agent:
             tracer.end_trace(trace_id, output=response)
 
     def reset(self):
-        """Clear conversation history."""
+        """Clear conversation history and per-call usage (lifetime totals kept)."""
         self._history = []
+        self._last_usage = _empty_usage()
 
     @property
     def history(self) -> list[dict]:
@@ -338,6 +442,16 @@ class Agent:
     @tracer.setter
     def tracer(self, value: BaseTracer | None):
         self._tracer = value
+
+    @property
+    def last_usage(self) -> dict[str, int]:
+        """Token usage from the most recent ``agent(...)`` call."""
+        return dict(self._last_usage)
+
+    @property
+    def total_usage(self) -> dict[str, int]:
+        """Cumulative token usage across the agent's lifetime."""
+        return dict(self._total_usage)
 
 
 class _AgentInstance:

--- a/underthesea/agent/providers/_http.py
+++ b/underthesea/agent/providers/_http.py
@@ -1,6 +1,10 @@
 """Shared HTTP helper using only Python stdlib."""
 
 import json
+import os
+import random
+import socket
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Generator
@@ -15,16 +19,70 @@ class LLMError(Exception):
         super().__init__(f"HTTP {status_code}: {body}")
 
 
-def post_json(url: str, headers: dict, body: dict, timeout: int = 120) -> dict:
-    """POST JSON and return parsed response."""
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+# Status codes worth retrying. 408/425 are transient client-side hints; 429 is
+# rate limiting; 5xx are upstream failures.
+_RETRYABLE_STATUS = {408, 425, 429, 500, 502, 503, 504, 529}
+
+
+def _default_max_retries() -> int:
+    """Override default with ``UNDERTHESEA_LLM_MAX_RETRIES`` env var."""
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as e:
-        error_body = e.read().decode("utf-8", errors="replace")
-        raise LLMError(e.code, error_body) from e
+        return max(0, int(os.environ.get("UNDERTHESEA_LLM_MAX_RETRIES", "3")))
+    except ValueError:
+        return 3
+
+
+def _retry_sleep(attempt: int, base_delay: float, max_delay: float) -> float:
+    """Exponential backoff with full jitter."""
+    delay = min(max_delay, base_delay * (2 ** attempt))
+    return random.uniform(0, delay)
+
+
+def post_json(
+    url: str,
+    headers: dict,
+    body: dict,
+    timeout: int = 120,
+    max_retries: int | None = None,
+    base_delay: float = 1.0,
+    max_delay: float = 30.0,
+) -> dict:
+    """POST JSON and return parsed response.
+
+    Retries transient failures (429, 5xx, connection / timeout errors) with
+    exponential backoff plus jitter.  Set ``max_retries=0`` to disable, or use
+    the ``UNDERTHESEA_LLM_MAX_RETRIES`` env var to change the default.
+    """
+    if max_retries is None:
+        max_retries = _default_max_retries()
+
+    data = json.dumps(body).encode("utf-8")
+    last_exc: Exception | None = None
+
+    for attempt in range(max_retries + 1):
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8", errors="replace")
+            err = LLMError(e.code, error_body)
+            if attempt < max_retries and e.code in _RETRYABLE_STATUS:
+                time.sleep(_retry_sleep(attempt, base_delay, max_delay))
+                last_exc = err
+                continue
+            raise err from e
+        except (urllib.error.URLError, socket.timeout, TimeoutError, ConnectionError) as e:
+            if attempt < max_retries:
+                time.sleep(_retry_sleep(attempt, base_delay, max_delay))
+                last_exc = e
+                continue
+            raise
+
+    # Defensive — loop above always returns or raises, but keep mypy happy.
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("post_json exhausted retries without raising")  # pragma: no cover
 
 
 def stream_sse(url: str, headers: dict, body: dict, timeout: int = 300) -> Generator[dict]:

--- a/underthesea/agent/providers/_http.py
+++ b/underthesea/agent/providers/_http.py
@@ -3,7 +3,6 @@
 import json
 import os
 import random
-import socket
 import time
 import urllib.error
 import urllib.request
@@ -72,7 +71,7 @@ def post_json(
                 last_exc = err
                 continue
             raise err from e
-        except (urllib.error.URLError, socket.timeout, TimeoutError, ConnectionError) as e:
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
             if attempt < max_retries:
                 time.sleep(_retry_sleep(attempt, base_delay, max_delay))
                 last_exc = e

--- a/underthesea/agent/tools.py
+++ b/underthesea/agent/tools.py
@@ -1,8 +1,10 @@
 """Tool class for agent function calling."""
 import inspect
 import json
+import re
+import typing
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal, Union, get_args, get_origin
 
 
 class Tool:
@@ -24,44 +26,45 @@ class Tool:
         name : str, optional
             Tool name. Defaults to function name.
         description : str, optional
-            Tool description. Defaults to function docstring.
+            Tool description. Defaults to function docstring (summary line).
         """
         self.func = func
         self.name = name or func.__name__
-        self.description = description or func.__doc__ or f"Tool: {self.name}"
+        docstring = func.__doc__ or ""
+        self._param_docs = _parse_param_docs(docstring)
+        self.description = description or _docstring_summary(docstring) or f"Tool: {self.name}"
         self.parameters = self._extract_parameters(func)
 
     def _extract_parameters(self, func: Callable) -> dict:
         """Extract JSON schema from function signature."""
         sig = inspect.signature(func)
-        hints = getattr(func, "__annotations__", {})
+        try:
+            hints = typing.get_type_hints(func)
+        except Exception:
+            hints = getattr(func, "__annotations__", {}) or {}
 
-        properties = {}
-        required = []
+        properties: dict[str, dict] = {}
+        required: list[str] = []
 
         for param_name, param in sig.parameters.items():
-            if param_name == "return":
+            if param_name in ("self", "cls"):
                 continue
             param_type = hints.get(param_name, str)
-            properties[param_name] = {
-                "type": self._python_type_to_json(param_type),
-                "description": f"Parameter {param_name}",
-            }
-            if param.default is inspect.Parameter.empty:
+            schema = _python_type_to_schema(param_type)
+            doc = self._param_docs.get(param_name)
+            schema["description"] = doc or f"Parameter {param_name}"
+            if param.default is not inspect.Parameter.empty:
+                # JSON schema "default" is informational; many providers honour it.
+                try:
+                    json.dumps(param.default)
+                    schema["default"] = param.default
+                except TypeError:
+                    pass
+            else:
                 required.append(param_name)
+            properties[param_name] = schema
 
         return {"type": "object", "properties": properties, "required": required}
-
-    def _python_type_to_json(self, py_type) -> str:
-        """Convert Python type to JSON schema type."""
-        mapping = {
-            str: "string",
-            int: "integer",
-            float: "number",
-            bool: "boolean",
-            list: "array",
-        }
-        return mapping.get(py_type, "string")
 
     def to_openai_tool(self) -> dict:
         """Convert to OpenAI tool format."""
@@ -83,10 +86,171 @@ class Tool:
         }
 
     def execute(self, arguments: dict) -> str:
-        """Execute tool and return JSON result."""
+        """Execute tool and return JSON-serialized result."""
         result = self.func(**arguments)
         return json.dumps(result, ensure_ascii=False, default=str)
 
     def __call__(self, **kwargs) -> Any:
         """Call the underlying function directly."""
         return self.func(**kwargs)
+
+
+def tool(
+    _func: Callable | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> Tool | Callable[[Callable], Tool]:
+    """Decorator that turns a function into a :class:`Tool`.
+
+    Examples
+    --------
+    >>> @tool
+    ... def add(a: int, b: int) -> int:
+    ...     '''Add two numbers.'''
+    ...     return a + b
+    >>> add.name
+    'add'
+
+    >>> @tool(name="search", description="Search the web")
+    ... def _search(query: str) -> list:
+    ...     ...
+    """
+    def wrap(fn: Callable) -> Tool:
+        return Tool(fn, name=name, description=description)
+
+    if _func is None:
+        return wrap
+    return wrap(_func)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_PRIMITIVE_TYPES: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+    dict: "object",
+    type(None): "null",
+}
+
+
+def _python_type_to_schema(py_type: Any) -> dict:
+    """Convert a Python type annotation to a JSON schema fragment.
+
+    Handles primitives, ``list[T]``, ``dict[K, V]``, ``Optional[T]``,
+    ``Union[...]`` and ``Literal[...]``.  Unknown types fall back to ``string``
+    so the LLM still gets a usable schema.
+    """
+    if py_type is inspect.Parameter.empty or py_type is None:
+        return {"type": "string"}
+
+    if py_type in _PRIMITIVE_TYPES:
+        return {"type": _PRIMITIVE_TYPES[py_type]}
+
+    origin = get_origin(py_type)
+    args = get_args(py_type)
+
+    if origin is Literal:
+        return {"type": _literal_type(args), "enum": list(args)}
+
+    if origin is Union:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            # Optional[T] — schema is T, nullability handled by "required".
+            return _python_type_to_schema(non_none[0])
+        # Multi-type union — pick the first known primitive, fall back to string.
+        for arg in non_none:
+            if arg in _PRIMITIVE_TYPES:
+                return {"type": _PRIMITIVE_TYPES[arg]}
+        return {"type": "string"}
+
+    if origin in (list, tuple, set, frozenset):
+        schema: dict = {"type": "array"}
+        if args:
+            schema["items"] = _python_type_to_schema(args[0])
+        return schema
+
+    if origin is dict:
+        schema = {"type": "object"}
+        if len(args) == 2:
+            schema["additionalProperties"] = _python_type_to_schema(args[1])
+        return schema
+
+    return {"type": "string"}
+
+
+def _literal_type(values: tuple) -> str:
+    """Infer the JSON type that fits all literal values."""
+    types = {type(v) for v in values}
+    if types <= {str}:
+        return "string"
+    if types <= {int, bool}:
+        return "integer" if types == {int} else "boolean"
+    if types <= {int, float}:
+        return "number"
+    return "string"
+
+
+_PARAM_HEADER_RE = re.compile(
+    r"^\s*(Args|Arguments|Parameters|Params)\s*:?\s*$", re.IGNORECASE,
+)
+_PARAM_LINE_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:\([^)]*\))?\s*[:\-]\s*(?P<desc>.+)$",
+)
+
+
+def _docstring_summary(docstring: str) -> str:
+    """Return the first non-empty line of a docstring."""
+    for line in (docstring or "").splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _parse_param_docs(docstring: str) -> dict[str, str]:
+    """Parse Google- and NumPy-style parameter descriptions from a docstring.
+
+    Recognises sections headed by ``Args:``, ``Arguments:``, ``Parameters`` or
+    ``Params:``.  Lines look like ``name: description`` or ``name (type):
+    description``.  Returns ``{}`` when nothing parses — callers should fall
+    back to a generic description.
+    """
+    if not docstring:
+        return {}
+
+    lines = inspect.cleandoc(docstring).splitlines()
+    in_section = False
+    params: dict[str, str] = {}
+    current: str | None = None
+
+    for line in lines:
+        if _PARAM_HEADER_RE.match(line):
+            in_section = True
+            current = None
+            continue
+        if in_section and not line.strip():
+            # Blank line ends Google-style block but not NumPy-style; be lenient
+            # and just reset the "current" continuation tracker.
+            current = None
+            continue
+        if in_section and line and not line.startswith((" ", "\t")) and ":" not in line:
+            # New unindented non-param header — section likely ended.
+            in_section = False
+            current = None
+            continue
+        if in_section:
+            match = _PARAM_LINE_RE.match(line)
+            if match:
+                current = match.group("name")
+                params[current] = match.group("desc").strip()
+            elif current and line.strip():
+                params[current] = f"{params[current]} {line.strip()}"
+
+    return params

--- a/underthesea/agent/wiki.py
+++ b/underthesea/agent/wiki.py
@@ -25,7 +25,6 @@ Usage:
 """
 
 import json
-import os
 import re
 import urllib.parse
 import urllib.request
@@ -579,7 +578,7 @@ class WikiAgent:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
         except Exception as e:
-            raise RuntimeError(f"Failed to fetch tweet: {e}")
+            raise RuntimeError(f"Failed to fetch tweet: {e}") from e
 
         tweet = data.get("tweet", {})
         author = tweet.get("author", {})
@@ -664,7 +663,7 @@ class WikiAgent:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 html = resp.read().decode("utf-8", errors="ignore")
         except Exception as e:
-            raise RuntimeError(f"Failed to fetch {url}: {e}")
+            raise RuntimeError(f"Failed to fetch {url}: {e}") from e
 
         # Extract title
         title_match = re.search(r"<title[^>]*>(.*?)</title>", html, re.DOTALL | re.IGNORECASE)


### PR DESCRIPTION
- Agent: run multiple tool calls concurrently (parallel_tools, max_tool_workers)
  and recover from tool failures by feeding the error back to the model
  (tool_error_handling="recover" by default, "raise" preserves old behavior)
- Agent: expose last_usage / total_usage token counters aggregated across
  iterations from the provider response
- Tools: add @tool decorator, parse Google-style "Args:" docstrings for
  parameter descriptions, and support Optional[T], list[T], dict[K, V],
  Literal[...] plus parameter defaults in the JSON schema
- HTTP: retry transient failures (429, 5xx, network errors) with exponential
  backoff and jitter; configurable via UNDERTHESEA_LLM_MAX_RETRIES