### PR TITLE
feat(agent): add A2A-compatible HTTP server

### DIFF
--- a/.github/workflows/ci-agent.yml
+++ b/.github/workflows/ci-agent.yml
@@ -1,0 +1,19 @@
+name: ci-agent
+
+on: [pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Test with tox
+        run: tox -e agent

--- a/.github/workflows/ci-agent.yml
+++ b/.github/workflows/ci-agent.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Install agent extras
+      - name: Install underthesea + httpx (ASGI test client)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[agent]"
+          pip install -e . httpx
       # Scope: only the server adapter tests. The rest of tests.agent.* targets
       # an older Agent API and is being migrated separately — broaden once green.
       - name: Run server adapter tests

--- a/.github/workflows/ci-agent.yml
+++ b/.github/workflows/ci-agent.yml
@@ -11,9 +11,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Install dependencies
+      - name: Install agent extras
         run: |
           python -m pip install --upgrade pip
-          pip install tox
-      - name: Test with tox
-        run: tox -e agent
+          pip install -e ".[agent]"
+      # Scope: only the server adapter tests. The rest of tests.agent.* targets
+      # an older Agent API and is being migrated separately — broaden once green.
+      - name: Run server adapter tests
+        run: python -m unittest tests.agent.test_server -v

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A2A-compatible HTTP server adapter `underthesea.agent.server` ([#1016](https://github.com/undertheseanlp/underthesea/pull/1016))
+  - `make_app(agent, path=...)` — raw ASGI callable (no web framework dep at the library level); plug into uvicorn / hypercorn / daphne / granian
+  - `serve(agent, ui=True)` — one-line uvicorn entrypoint with bundled chat UI at `{path}/ui`, JSON-RPC `message/stream` over HTTP+SSE, and a discoverable `AgentCard` at `{path}/.well-known/agent-card.json`
+  - Per-session `Agent` clone per A2A `contextId` so each conversation keeps isolated history
+  - Tool calls stream live as `tool_call` artifacts via a ContextVar hook around each `Tool.func` — the `Agent` class itself is unchanged
+  - Sync `Agent.__call__` offloaded via `asyncio.to_thread` to keep the event loop responsive
+  - Bundled chat UI is generic: title from `AgentCard`, RPC URL auto-discovered from `window.location`, modal-based agent card viewer
+  - New `[agent-server]` extra (`uvicorn + starlette + httpx`, version ranges aligned with [google-adk-python](https://github.com/google/adk-python))
+  - 17 tests via `httpx.ASGITransport`; new `ci-agent` workflow runs them on every PR
+
+### Fixed
+
+- `agent/wiki.py` ruff lint errors (unused `os` import, two `B904` missing `raise ... from`) that previously blocked CI on any PR ([#1016](https://github.com/undertheseanlp/underthesea/pull/1016))
+
 ## [9.4.0] - 2026-04-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ underthesea = [
   "**/*.txt",
   "**/*.pkl",
   "**/*.json",
+  "agent/static/*.html",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ prompt = [
     "openai"
 ]
 agent = []
+agent-server = [
+    "uvicorn>=0.30",
+]
 trace = [
     "langfuse>=2.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,9 @@ prompt = [
     "openai"
 ]
 agent = [
-    "a2a-sdk[http-server]==0.3.24",
+    "starlette>=0.40",
     "uvicorn>=0.30",
+    "httpx>=0.27",
 ]
 trace = [
     "langfuse>=2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,7 @@ voice = [
 prompt = [
     "openai"
 ]
-agent = [
-    "starlette>=0.40",
-    "uvicorn>=0.30",
-    "httpx>=0.27",
-]
+agent = []
 trace = [
     "langfuse>=2.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,9 @@ prompt = [
 ]
 agent = []
 agent-server = [
-    "uvicorn>=0.30",
+    "uvicorn>=0.34,<1",
+    "starlette>=0.49.1,<1",
+    "httpx>=0.27,<1",
 ]
 trace = [
     "langfuse>=2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ voice = [
 prompt = [
     "openai"
 ]
-agent = []
+agent = [
+    "a2a-sdk[http-server]==0.3.24",
+    "uvicorn>=0.30",
+]
 trace = [
     "langfuse>=2.0.0"
 ]

--- a/tests/agent/test_server.py
+++ b/tests/agent/test_server.py
@@ -2,6 +2,7 @@
 import json
 import unittest
 from unittest import TestCase
+from unittest.mock import patch
 
 try:
     from starlette.testclient import TestClient
@@ -25,7 +26,7 @@ def _double(x: int) -> int:
     return x * 2
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
 class TestRecordTool(TestCase):
     def test_records_call_when_trace_active(self):
         wrapped = _record_tool(_double)
@@ -50,7 +51,7 @@ class TestRecordTool(TestCase):
         self.assertEqual(wrapped.__doc__, "Doubles input.")
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
 class TestWrapToolsInplace(TestCase):
     def test_wraps_func_and_sets_marker(self):
         tool = Tool(_double)
@@ -79,7 +80,7 @@ class TestWrapToolsInplace(TestCase):
         self.assertEqual(trace[0]["args"], {"x": 7})
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
 class TestSpawnSessionAgent(TestCase):
     def test_clones_template_with_isolated_history(self):
         template = Agent(
@@ -109,7 +110,7 @@ class TestSpawnSessionAgent(TestCase):
         self.assertIs(session._tracer, sentinel_tracer)
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
 class TestAutoAgentCard(TestCase):
     def test_required_fields_present(self):
         agent = Agent(
@@ -132,7 +133,15 @@ class TestAutoAgentCard(TestCase):
         self.assertLessEqual(len(card["description"]), 200)
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+def _parse_sse(text: str) -> list[dict]:
+    return [
+        json.loads(line[6:])
+        for line in text.split("\n")
+        if line.startswith("data: ")
+    ]
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
 class TestMakeApp(TestCase):
     def _agent(self):
         return Agent(
@@ -160,7 +169,7 @@ class TestMakeApp(TestCase):
         body = client.get("/a2a/x/.well-known/agent-card.json").json()
         self.assertEqual(body["name"], "Overridden")
 
-    def test_rpc_endpoint_mounted(self):
+    def test_rpc_and_card_routes_mounted(self):
         app = make_app(self._agent(), path="/a2a/x", host="127.0.0.1", port=8765)
         paths = {getattr(r, "path", None) for r in app.routes}
         self.assertIn("/a2a/x", paths)
@@ -172,6 +181,100 @@ class TestMakeApp(TestCase):
         self.assertTrue(
             getattr(agent.tools[0].func, "__uts_server_wrapped__", False)
         )
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
+class TestRpcStream(TestCase):
+    def test_stream_emits_full_a2a_event_sequence(self):
+        """End-to-end: POST message/stream → SSE with all expected events."""
+        agent = Agent(
+            name="A", instruction="i", tools=[Tool(_double)],
+        )
+
+        def fake_call(self_agent, message, **kwargs):
+            trace = _trace_var.get()
+            if trace is not None:
+                trace.append({"tool": "_double", "args": {"x": 1}, "result": 2})
+            return "fake reply"
+
+        with patch.object(Agent, "__call__", fake_call):
+            app = make_app(agent, path="/a2a/x", host="127.0.0.1", port=8765)
+            client = TestClient(app)
+            r = client.post("/a2a/x", json={
+                "jsonrpc": "2.0", "id": "rpc-1",
+                "method": "message/stream",
+                "params": {"message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "hi"}],
+                    "messageId": "m1",
+                    "contextId": "ctx-stream-test",
+                }},
+            })
+
+        self.assertEqual(r.status_code, 200)
+        events = _parse_sse(r.text)
+
+        # Every event must wrap a result in JSON-RPC 2.0 envelope with our rpc-id.
+        for ev in events:
+            self.assertEqual(ev["jsonrpc"], "2.0")
+            self.assertEqual(ev["id"], "rpc-1")
+            self.assertEqual(ev["result"]["contextId"], "ctx-stream-test")
+
+        kinds = [ev["result"]["kind"] for ev in events]
+        self.assertEqual(
+            kinds,
+            ["status-update", "status-update",
+             "artifact-update", "artifact-update", "status-update"],
+        )
+
+        # Status transitions: submitted → working → completed (final=true).
+        statuses = [
+            ev["result"]["status"]["state"]
+            for ev in events if ev["result"]["kind"] == "status-update"
+        ]
+        self.assertEqual(statuses, ["submitted", "working", "completed"])
+        self.assertTrue(events[-1]["result"]["final"])
+
+        # Artifacts: tool_call data part + reply text part.
+        artifacts = [
+            ev["result"]["artifact"]
+            for ev in events if ev["result"]["kind"] == "artifact-update"
+        ]
+        self.assertEqual([a["name"] for a in artifacts], ["tool_call", "reply"])
+        self.assertEqual(
+            artifacts[0]["parts"][0]["data"]["tool_call"],
+            {"tool": "_double", "args": {"x": 1}, "result": 2},
+        )
+        self.assertEqual(artifacts[1]["parts"][0]["text"], "fake reply")
+
+    def test_stream_generates_ids_when_missing(self):
+        agent = Agent(name="A", instruction="i", tools=[Tool(_double)])
+
+        def fake_call(_self, _message, **_kwargs):
+            return "ok"
+
+        with patch.object(Agent, "__call__", fake_call):
+            app = make_app(agent, path="/a2a/x", host="127.0.0.1", port=8765)
+            client = TestClient(app)
+            r = client.post("/a2a/x", json={
+                "jsonrpc": "2.0", "id": "rpc-2",
+                "method": "message/stream",
+                "params": {"message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "hi"}],
+                    "messageId": "m1",
+                    # no contextId, no taskId
+                }},
+            })
+
+        events = _parse_sse(r.text)
+        # IDs should be generated and identical across all events in the response.
+        ctx_ids = {ev["result"]["contextId"] for ev in events}
+        task_ids = {ev["result"]["taskId"] for ev in events}
+        self.assertEqual(len(ctx_ids), 1)
+        self.assertEqual(len(task_ids), 1)
+        self.assertTrue(next(iter(ctx_ids)))
+        self.assertTrue(next(iter(task_ids)))
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_server.py
+++ b/tests/agent/test_server.py
@@ -38,7 +38,7 @@ class TestRecordTool(TestCase):
             _trace_var.reset(token)
         self.assertEqual(result, 10)
         self.assertEqual(
-            trace, [{"tool": "_double", "args": {"x": 5}, "result": 10}]
+            trace, [{"name": "_double", "args": {"x": 5}, "result": 10}]
         )
 
     def test_silent_when_no_trace(self):
@@ -194,7 +194,7 @@ class TestRpcStream(TestCase):
         def fake_call(self_agent, message, **kwargs):
             trace = _trace_var.get()
             if trace is not None:
-                trace.append({"tool": "_double", "args": {"x": 1}, "result": 2})
+                trace.append({"name": "_double", "args": {"x": 1}, "result": 2})
             return "fake reply"
 
         with patch.object(Agent, "__call__", fake_call):
@@ -243,7 +243,7 @@ class TestRpcStream(TestCase):
         self.assertEqual([a["name"] for a in artifacts], ["tool_call", "reply"])
         self.assertEqual(
             artifacts[0]["parts"][0]["data"]["tool_call"],
-            {"tool": "_double", "args": {"x": 1}, "result": 2},
+            {"name": "_double", "args": {"x": 1}, "result": 2},
         )
         self.assertEqual(artifacts[1]["parts"][0]["text"], "fake reply")
 

--- a/tests/agent/test_server.py
+++ b/tests/agent/test_server.py
@@ -1,0 +1,178 @@
+"""Tests for underthesea.agent.server."""
+import json
+import unittest
+from unittest import TestCase
+
+try:
+    from starlette.testclient import TestClient
+
+    from underthesea.agent import Agent, Tool
+    from underthesea.agent.server import (
+        _auto_agent_card,
+        _record_tool,
+        _spawn_session_agent,
+        _trace_var,
+        _wrap_tools_inplace,
+        make_app,
+    )
+    SERVER_AVAILABLE = True
+except ImportError:
+    SERVER_AVAILABLE = False
+
+
+def _double(x: int) -> int:
+    """Doubles input."""
+    return x * 2
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+class TestRecordTool(TestCase):
+    def test_records_call_when_trace_active(self):
+        wrapped = _record_tool(_double)
+        trace: list = []
+        token = _trace_var.set(trace)
+        try:
+            result = wrapped(x=5)
+        finally:
+            _trace_var.reset(token)
+        self.assertEqual(result, 10)
+        self.assertEqual(
+            trace, [{"tool": "_double", "args": {"x": 5}, "result": 10}]
+        )
+
+    def test_silent_when_no_trace(self):
+        wrapped = _record_tool(_double)
+        self.assertEqual(wrapped(x=3), 6)
+
+    def test_preserves_function_metadata(self):
+        wrapped = _record_tool(_double)
+        self.assertEqual(wrapped.__name__, "_double")
+        self.assertEqual(wrapped.__doc__, "Doubles input.")
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+class TestWrapToolsInplace(TestCase):
+    def test_wraps_func_and_sets_marker(self):
+        tool = Tool(_double)
+        original = tool.func
+        _wrap_tools_inplace([tool])
+        self.assertIsNot(tool.func, original)
+        self.assertTrue(getattr(tool.func, "__uts_server_wrapped__", False))
+
+    def test_idempotent(self):
+        tool = Tool(_double)
+        _wrap_tools_inplace([tool])
+        first = tool.func
+        _wrap_tools_inplace([tool])
+        self.assertIs(tool.func, first)
+
+    def test_wrapped_func_records_via_contextvar(self):
+        tool = Tool(_double)
+        _wrap_tools_inplace([tool])
+        trace: list = []
+        token = _trace_var.set(trace)
+        try:
+            result = tool.execute({"x": 7})
+        finally:
+            _trace_var.reset(token)
+        self.assertEqual(json.loads(result), 14)
+        self.assertEqual(trace[0]["args"], {"x": 7})
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+class TestSpawnSessionAgent(TestCase):
+    def test_clones_template_with_isolated_history(self):
+        template = Agent(
+            name="T", instruction="instr",
+            tools=[Tool(_double)], max_iterations=7,
+        )
+        template._history.append({"role": "user", "content": "prior"})
+
+        session = _spawn_session_agent(template)
+
+        self.assertEqual(session.name, "T")
+        self.assertEqual(session.instruction, "instr")
+        self.assertEqual(session.max_iterations, 7)
+        self.assertIs(session.tools[0], template.tools[0])
+        self.assertEqual(len(session.history), 0)
+
+    def test_shares_provider_and_tracer(self):
+        template = Agent(name="T", instruction="i", tools=[Tool(_double)])
+        sentinel_provider = object()
+        sentinel_tracer = object()
+        template._provider = sentinel_provider
+        template._tracer = sentinel_tracer
+
+        session = _spawn_session_agent(template)
+
+        self.assertIs(session._provider, sentinel_provider)
+        self.assertIs(session._tracer, sentinel_tracer)
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+class TestAutoAgentCard(TestCase):
+    def test_required_fields_present(self):
+        agent = Agent(
+            name="MathAgent", instruction="Be helpful",
+            tools=[Tool(_double)],
+        )
+        card = _auto_agent_card(agent, "http://localhost:8000/a2a/math")
+
+        self.assertEqual(card["name"], "MathAgent")
+        self.assertEqual(card["url"], "http://localhost:8000/a2a/math")
+        self.assertEqual(card["preferredTransport"], "JSONRPC")
+        self.assertTrue(card["capabilities"]["streaming"])
+        self.assertEqual(len(card["skills"]), 1)
+        self.assertEqual(card["skills"][0]["id"], "_double")
+        self.assertEqual(card["skills"][0]["description"], "Doubles input.")
+
+    def test_truncates_long_instruction(self):
+        agent = Agent(name="X", instruction="a" * 500, tools=[])
+        card = _auto_agent_card(agent, "http://x/")
+        self.assertLessEqual(len(card["description"]), 200)
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "a2a-sdk[http-server] not installed")
+class TestMakeApp(TestCase):
+    def _agent(self):
+        return Agent(
+            name="TestAgent", instruction="i",
+            tools=[Tool(_double)],
+        )
+
+    def test_card_route_serves_auto_generated_card(self):
+        app = make_app(self._agent(), path="/a2a/x", host="127.0.0.1", port=8765)
+        client = TestClient(app)
+        r = client.get("/a2a/x/.well-known/agent-card.json")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["name"], "TestAgent")
+        self.assertEqual(body["url"], "http://127.0.0.1:8765/a2a/x")
+
+    def test_card_route_serves_override(self):
+        custom = _auto_agent_card(self._agent(), "http://x:1/y")
+        custom["name"] = "Overridden"
+        app = make_app(
+            self._agent(), path="/a2a/x", agent_card=custom,
+            host="127.0.0.1", port=8765,
+        )
+        client = TestClient(app)
+        body = client.get("/a2a/x/.well-known/agent-card.json").json()
+        self.assertEqual(body["name"], "Overridden")
+
+    def test_rpc_endpoint_mounted(self):
+        app = make_app(self._agent(), path="/a2a/x", host="127.0.0.1", port=8765)
+        paths = {getattr(r, "path", None) for r in app.routes}
+        self.assertIn("/a2a/x", paths)
+        self.assertIn("/a2a/x/.well-known/agent-card.json", paths)
+
+    def test_tools_wrapped_after_make_app(self):
+        agent = self._agent()
+        make_app(agent, path="/a2a/x", host="127.0.0.1", port=8765)
+        self.assertTrue(
+            getattr(agent.tools[0].func, "__uts_server_wrapped__", False)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_server.py
+++ b/tests/agent/test_server.py
@@ -1,11 +1,11 @@
 """Tests for underthesea.agent.server."""
 import json
 import unittest
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import patch
 
 try:
-    from starlette.testclient import TestClient
+    import httpx
 
     from underthesea.agent import Agent, Tool
     from underthesea.agent.server import (
@@ -26,7 +26,30 @@ def _double(x: int) -> int:
     return x * 2
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
+def _make_agent() -> "Agent":
+    return Agent(
+        name="TestAgent", instruction="i",
+        tools=[Tool(_double)],
+    )
+
+
+def _client(app):
+    """httpx AsyncClient that drives the raw ASGI app in-process."""
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://t",
+    )
+
+
+def _parse_sse(text: str) -> list[dict]:
+    return [
+        json.loads(line[6:])
+        for line in text.split("\n")
+        if line.startswith("data: ")
+    ]
+
+
+@unittest.skipUnless(SERVER_AVAILABLE, "httpx not installed")
 class TestRecordTool(TestCase):
     def test_records_call_when_trace_active(self):
         wrapped = _record_tool(_double)
@@ -51,7 +74,7 @@ class TestRecordTool(TestCase):
         self.assertEqual(wrapped.__doc__, "Doubles input.")
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "httpx not installed")
 class TestWrapToolsInplace(TestCase):
     def test_wraps_func_and_sets_marker(self):
         tool = Tool(_double)
@@ -80,7 +103,7 @@ class TestWrapToolsInplace(TestCase):
         self.assertEqual(trace[0]["args"], {"x": 7})
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "httpx not installed")
 class TestSpawnSessionAgent(TestCase):
     def test_clones_template_with_isolated_history(self):
         template = Agent(
@@ -110,7 +133,7 @@ class TestSpawnSessionAgent(TestCase):
         self.assertIs(session._tracer, sentinel_tracer)
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
+@unittest.skipUnless(SERVER_AVAILABLE, "httpx not installed")
 class TestAutoAgentCard(TestCase):
     def test_required_fields_present(self):
         agent = Agent(
@@ -133,63 +156,57 @@ class TestAutoAgentCard(TestCase):
         self.assertLessEqual(len(card["description"]), 200)
 
 
-def _parse_sse(text: str) -> list[dict]:
-    return [
-        json.loads(line[6:])
-        for line in text.split("\n")
-        if line.startswith("data: ")
-    ]
-
-
-@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
-class TestMakeApp(TestCase):
-    def _agent(self):
-        return Agent(
-            name="TestAgent", instruction="i",
-            tools=[Tool(_double)],
-        )
-
-    def test_card_route_serves_auto_generated_card(self):
-        app = make_app(self._agent(), path="/a2a/x", host="127.0.0.1", port=8765)
-        client = TestClient(app)
-        r = client.get("/a2a/x/.well-known/agent-card.json")
+@unittest.skipUnless(SERVER_AVAILABLE, "httpx not installed")
+class TestMakeApp(IsolatedAsyncioTestCase):
+    async def test_card_route_serves_auto_generated_card(self):
+        app = make_app(_make_agent(), path="/a2a/x", host="127.0.0.1", port=8765)
+        async with _client(app) as c:
+            r = await c.get("/a2a/x/.well-known/agent-card.json")
         self.assertEqual(r.status_code, 200)
         body = r.json()
         self.assertEqual(body["name"], "TestAgent")
         self.assertEqual(body["url"], "http://127.0.0.1:8765/a2a/x")
 
-    def test_card_route_serves_override(self):
-        custom = _auto_agent_card(self._agent(), "http://x:1/y")
+    async def test_card_route_serves_override(self):
+        custom = _auto_agent_card(_make_agent(), "http://x:1/y")
         custom["name"] = "Overridden"
         app = make_app(
-            self._agent(), path="/a2a/x", agent_card=custom,
+            _make_agent(), path="/a2a/x", agent_card=custom,
             host="127.0.0.1", port=8765,
         )
-        client = TestClient(app)
-        body = client.get("/a2a/x/.well-known/agent-card.json").json()
-        self.assertEqual(body["name"], "Overridden")
+        async with _client(app) as c:
+            r = await c.get("/a2a/x/.well-known/agent-card.json")
+        self.assertEqual(r.json()["name"], "Overridden")
 
-    def test_rpc_and_card_routes_mounted(self):
-        app = make_app(self._agent(), path="/a2a/x", host="127.0.0.1", port=8765)
-        paths = {getattr(r, "path", None) for r in app.routes}
-        self.assertIn("/a2a/x", paths)
-        self.assertIn("/a2a/x/.well-known/agent-card.json", paths)
+    async def test_unknown_route_returns_404(self):
+        app = make_app(_make_agent(), path="/a2a/x", host="127.0.0.1", port=8765)
+        async with _client(app) as c:
+            r = await c.get("/no-such-route")
+        self.assertEqual(r.status_code, 404)
+
+    async def test_options_returns_cors_preflight(self):
+        app = make_app(_make_agent(), path="/a2a/x", host="127.0.0.1", port=8765)
+        async with _client(app) as c:
+            r = await c.request(
+                "OPTIONS", "/a2a/x", headers={"origin": "http://app.local"},
+            )
+        self.assertEqual(r.status_code, 204)
+        self.assertIn("access-control-allow-origin", r.headers)
+        self.assertEqual(r.headers["access-control-allow-origin"], "http://app.local")
 
     def test_tools_wrapped_after_make_app(self):
-        agent = self._agent()
+        agent = _make_agent()
         make_app(agent, path="/a2a/x", host="127.0.0.1", port=8765)
         self.assertTrue(
             getattr(agent.tools[0].func, "__uts_server_wrapped__", False)
         )
 
 
-@unittest.skipUnless(SERVER_AVAILABLE, "starlette + httpx not installed")
-class TestRpcStream(TestCase):
-    def test_stream_emits_full_a2a_event_sequence(self):
+@unittest.skipUnless(SERVER_AVAILABLE, "httpx not installed")
+class TestRpcStream(IsolatedAsyncioTestCase):
+    async def test_stream_emits_full_a2a_event_sequence(self):
         """End-to-end: POST message/stream → SSE with all expected events."""
-        agent = Agent(
-            name="A", instruction="i", tools=[Tool(_double)],
-        )
+        agent = Agent(name="A", instruction="i", tools=[Tool(_double)])
 
         def fake_call(self_agent, message, **kwargs):
             trace = _trace_var.get()
@@ -199,22 +216,21 @@ class TestRpcStream(TestCase):
 
         with patch.object(Agent, "__call__", fake_call):
             app = make_app(agent, path="/a2a/x", host="127.0.0.1", port=8765)
-            client = TestClient(app)
-            r = client.post("/a2a/x", json={
-                "jsonrpc": "2.0", "id": "rpc-1",
-                "method": "message/stream",
-                "params": {"message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": "hi"}],
-                    "messageId": "m1",
-                    "contextId": "ctx-stream-test",
-                }},
-            })
+            async with _client(app) as c:
+                r = await c.post("/a2a/x", json={
+                    "jsonrpc": "2.0", "id": "rpc-1",
+                    "method": "message/stream",
+                    "params": {"message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "hi"}],
+                        "messageId": "m1",
+                        "contextId": "ctx-stream-test",
+                    }},
+                })
 
         self.assertEqual(r.status_code, 200)
         events = _parse_sse(r.text)
 
-        # Every event must wrap a result in JSON-RPC 2.0 envelope with our rpc-id.
         for ev in events:
             self.assertEqual(ev["jsonrpc"], "2.0")
             self.assertEqual(ev["id"], "rpc-1")
@@ -227,7 +243,6 @@ class TestRpcStream(TestCase):
              "artifact-update", "artifact-update", "status-update"],
         )
 
-        # Status transitions: submitted → working → completed (final=true).
         statuses = [
             ev["result"]["status"]["state"]
             for ev in events if ev["result"]["kind"] == "status-update"
@@ -235,7 +250,6 @@ class TestRpcStream(TestCase):
         self.assertEqual(statuses, ["submitted", "working", "completed"])
         self.assertTrue(events[-1]["result"]["final"])
 
-        # Artifacts: tool_call data part + reply text part.
         artifacts = [
             ev["result"]["artifact"]
             for ev in events if ev["result"]["kind"] == "artifact-update"
@@ -247,7 +261,7 @@ class TestRpcStream(TestCase):
         )
         self.assertEqual(artifacts[1]["parts"][0]["text"], "fake reply")
 
-    def test_stream_generates_ids_when_missing(self):
+    async def test_stream_generates_ids_when_missing(self):
         agent = Agent(name="A", instruction="i", tools=[Tool(_double)])
 
         def fake_call(_self, _message, **_kwargs):
@@ -255,20 +269,18 @@ class TestRpcStream(TestCase):
 
         with patch.object(Agent, "__call__", fake_call):
             app = make_app(agent, path="/a2a/x", host="127.0.0.1", port=8765)
-            client = TestClient(app)
-            r = client.post("/a2a/x", json={
-                "jsonrpc": "2.0", "id": "rpc-2",
-                "method": "message/stream",
-                "params": {"message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": "hi"}],
-                    "messageId": "m1",
-                    # no contextId, no taskId
-                }},
-            })
+            async with _client(app) as c:
+                r = await c.post("/a2a/x", json={
+                    "jsonrpc": "2.0", "id": "rpc-2",
+                    "method": "message/stream",
+                    "params": {"message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "hi"}],
+                        "messageId": "m1",
+                    }},
+                })
 
         events = _parse_sse(r.text)
-        # IDs should be generated and identical across all events in the response.
         ctx_ids = {ev["result"]["contextId"] for ev in events}
         task_ids = {ev["result"]["taskId"] for ev in events}
         self.assertEqual(len(ctx_ids), 1)

--- a/underthesea/agent/__init__.py
+++ b/underthesea/agent/__init__.py
@@ -1,5 +1,4 @@
 from underthesea.agent.agent import Agent, agent
-from underthesea.agent.wiki import WikiAgent
 from underthesea.agent.default_tools import (
     calculator_tool,
     core_tools,
@@ -32,6 +31,7 @@ from underthesea.agent.providers import (
 )
 from underthesea.agent.tools import Tool
 from underthesea.agent.trace import BaseTracer, LangfuseTracer, LocalTracer
+from underthesea.agent.wiki import WikiAgent
 
 __all__ = [
     # Core

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -1,11 +1,18 @@
 """A2A-compatible HTTP server for Agent instances.
 
-Wraps an :class:`Agent` so it speaks the A2A protocol — JSON-RPC over HTTP
-with SSE streaming, plus a discoverable AgentCard at
-``{path}/.well-known/agent-card.json``. One :class:`Agent` is spawned per
-A2A ``context_id`` so each conversation keeps its own history.
+Implements the A2A wire protocol — JSON-RPC 2.0 ``message/stream`` over HTTP
+with SSE streaming — on top of plain Starlette. No a2a-sdk dependency.
 
-Requires ``a2a-sdk[http-server]`` (Starlette + sse-starlette).
+Endpoints
+---------
+- ``POST {path}``                              — JSON-RPC ``message/stream``
+- ``GET  {path}/.well-known/agent-card.json``  — discoverable AgentCard
+
+One :class:`Agent` is spawned per A2A ``contextId`` so each conversation
+keeps its own history. Tool calls are streamed live as ``tool_call``
+artifacts via a ContextVar hook around each ``Tool.func``.
+
+Requires ``starlette`` + ``uvicorn`` (install via ``underthesea[agent]``).
 
 Example
 -------
@@ -20,9 +27,6 @@ Example
 
     agent = Agent(name="MathAgent", instruction="...", tools=[Tool(add)])
     serve(agent, port=8000, path="/a2a/math")
-
-Use :func:`make_app` instead of :func:`serve` if you need to mount extra
-routes (e.g. a static UI) on the returned Starlette app.
 """
 import asyncio
 import contextvars
@@ -30,20 +34,14 @@ import functools
 import json
 import uuid
 from collections.abc import Callable
+from datetime import UTC, datetime
 
 import uvicorn
-from a2a.server.agent_execution.agent_executor import AgentExecutor
-from a2a.server.agent_execution.simple_request_context_builder import (
-    SimpleRequestContextBuilder,
-)
-from a2a.server.apps.jsonrpc.starlette_app import A2AStarletteApplication
-from a2a.server.request_handlers.default_request_handler import DefaultRequestHandler
-from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
-from a2a.server.tasks.task_updater import TaskUpdater
-from a2a.types import AgentCard, Part
-from a2a.utils.parts import get_text_parts
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
-from starlette.responses import Response
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
 from starlette.routing import Route
 
 from underthesea.agent.agent import Agent
@@ -108,50 +106,86 @@ def _auto_agent_card(agent: Agent, url: str) -> dict:
     }
 
 
-class _SessionAgentExecutor(AgentExecutor):
-    """A2A executor that spawns one Agent per A2A ``context_id``."""
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _extract_user_text(parts: list[dict]) -> str:
+    for p in parts or []:
+        if p.get("kind") == "text":
+            return (p.get("text") or "").strip()
+    return ""
+
+
+def _sse_event(rpc_id, result: dict) -> bytes:
+    payload = {"id": rpc_id, "jsonrpc": "2.0", "result": result}
+    return f"data: {json.dumps(payload)}\n\n".encode()
+
+
+class _SessionRouter:
+    """Maps A2A contextId → spawned Agent; owns the streaming RPC handler."""
 
     def __init__(self, template: Agent):
         self._template = template
         self._sessions: dict[str, Agent] = {}
 
-    async def execute(self, context, event_queue) -> None:
-        updater = TaskUpdater(
-            event_queue,
-            task_id=context.task_id or str(uuid.uuid4()),
-            context_id=context.context_id or str(uuid.uuid4()),
-        )
-        await updater.submit()
-        await updater.start_work()
+    def _session(self, context_id: str) -> Agent:
+        if context_id not in self._sessions:
+            self._sessions[context_id] = _spawn_session_agent(self._template)
+        return self._sessions[context_id]
 
-        text_parts = get_text_parts(context.message.parts if context.message else [])
-        user_message = (text_parts[0] if text_parts else "").strip()
+    async def handle_rpc(self, request: Request) -> Response:
+        body = await request.json()
+        rpc_id = body.get("id")
+        params = body.get("params", {})
+        message = params.get("message", {})
 
-        if updater.context_id not in self._sessions:
-            self._sessions[updater.context_id] = _spawn_session_agent(self._template)
-        agent = self._sessions[updater.context_id]
-        trace: list[dict] = []
-        token = _trace_var.set(trace)
-        try:
-            reply = await asyncio.to_thread(agent, user_message)
-        finally:
-            _trace_var.reset(token)
+        user_text = _extract_user_text(message.get("parts", []))
+        context_id = message.get("contextId") or str(uuid.uuid4())
+        task_id = message.get("taskId") or str(uuid.uuid4())
+        agent = self._session(context_id)
 
-        for step in trace:
-            await updater.add_artifact(
-                [Part.model_validate(
-                    {"kind": "data", "data": {"tool_call": step}}
-                )],
-                name="tool_call",
-            )
-        await updater.add_artifact(
-            [Part.model_validate({"kind": "text", "text": reply})],
-            name="reply",
-        )
-        await updater.complete()
+        async def stream():
+            for state in ("submitted", "working"):
+                yield _sse_event(rpc_id, {
+                    "contextId": context_id, "taskId": task_id,
+                    "kind": "status-update", "final": False,
+                    "status": {"state": state, "timestamp": _now_iso()},
+                })
 
-    async def cancel(self, context, event_queue) -> None:
-        pass
+            trace: list[dict] = []
+            token = _trace_var.set(trace)
+            try:
+                reply = await asyncio.to_thread(agent, user_text)
+            finally:
+                _trace_var.reset(token)
+
+            for step in trace:
+                yield _sse_event(rpc_id, {
+                    "contextId": context_id, "taskId": task_id,
+                    "kind": "artifact-update",
+                    "artifact": {
+                        "artifactId": str(uuid.uuid4()),
+                        "name": "tool_call",
+                        "parts": [{"kind": "data", "data": {"tool_call": step}}],
+                    },
+                })
+            yield _sse_event(rpc_id, {
+                "contextId": context_id, "taskId": task_id,
+                "kind": "artifact-update",
+                "artifact": {
+                    "artifactId": str(uuid.uuid4()),
+                    "name": "reply",
+                    "parts": [{"kind": "text", "text": reply}],
+                },
+            })
+            yield _sse_event(rpc_id, {
+                "contextId": context_id, "taskId": task_id,
+                "kind": "status-update", "final": True,
+                "status": {"state": "completed", "timestamp": _now_iso()},
+            })
+
+        return StreamingResponse(stream(), media_type="text/event-stream")
 
 
 def make_app(
@@ -162,18 +196,18 @@ def make_app(
     host: str = "127.0.0.1",
     port: int = 8000,
     allow_origins: list[str] | None = None,
-):
-    """Build a Starlette ASGI app serving ``agent`` over A2A.
+) -> Starlette:
+    """Build a Starlette app serving ``agent`` over A2A.
 
     Parameters
     ----------
     agent : Agent
-        Template agent; per-session copies are spawned to isolate history.
+        Template agent; per-session copies share its tools/instruction/provider.
     path : str
         JSON-RPC endpoint, e.g. ``"/a2a/my_agent"``. The agent card is mounted
         at ``f"{path}/.well-known/agent-card.json"``.
     agent_card : dict, optional
-        Override the auto-generated AgentCard.
+        Override the auto-generated AgentCard (served verbatim).
     host, port : str, int
         Used only to fill the ``url`` field of the auto-generated card.
     allow_origins : list[str], optional
@@ -185,28 +219,25 @@ def make_app(
     card_bytes = json.dumps(card_dict).encode("utf-8")
     card_path = f"{path}/.well-known/agent-card.json"
 
-    async def serve_card(_request):
+    router = _SessionRouter(agent)
+
+    async def serve_card(_request: Request) -> Response:
         return Response(content=card_bytes, media_type="application/json")
 
-    handler = DefaultRequestHandler(
-        agent_executor=_SessionAgentExecutor(agent),
-        task_store=InMemoryTaskStore(),
-        request_context_builder=SimpleRequestContextBuilder(),
-    )
-    app = A2AStarletteApplication(
-        agent_card=AgentCard.model_validate(card_dict),
-        http_handler=handler,
-    ).build(rpc_url=path, agent_card_url=card_path)
-    # Ours wins because Starlette uses first-match routing.
-    app.routes.insert(0, Route(card_path, serve_card, methods=["GET"]))
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=allow_origins or ["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-    return app
+    routes = [
+        Route(card_path, serve_card, methods=["GET"]),
+        Route(path, router.handle_rpc, methods=["POST"]),
+    ]
+    middleware = [
+        Middleware(
+            CORSMiddleware,
+            allow_origins=allow_origins or ["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        ),
+    ]
+    return Starlette(routes=routes, middleware=middleware)
 
 
 def serve(
@@ -217,7 +248,7 @@ def serve(
     path: str = "/a2a",
     agent_card: dict | None = None,
     log_level: str = "info",
-):
+) -> None:
     """Run a blocking uvicorn server hosting ``agent`` over A2A.
 
     Convenience entrypoint — use :func:`make_app` if you need to attach extra

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -1,25 +1,26 @@
-"""A2A-compatible HTTP server for Agent instances.
+"""A2A-compatible HTTP server for Agent instances — raw ASGI, no web framework.
 
 Implements the A2A wire protocol — JSON-RPC 2.0 ``message/stream`` over HTTP
-with SSE streaming — on top of plain Starlette. No a2a-sdk dependency.
+with SSE streaming — as a plain ASGI callable. No starlette / fastapi
+dependency at the library level; users plug the returned app into any ASGI
+server they prefer (uvicorn, hypercorn, daphne, ...).
 
 Endpoints
 ---------
 - ``POST {path}``                              — JSON-RPC ``message/stream``
 - ``GET  {path}/.well-known/agent-card.json``  — discoverable AgentCard
+- ``OPTIONS *``                                — CORS preflight
 
 One :class:`Agent` is spawned per A2A ``contextId`` so each conversation
 keeps its own history. Tool calls are streamed live as ``tool_call``
 artifacts via a ContextVar hook around each ``Tool.func``.
-
-Requires ``starlette`` + ``uvicorn`` (install via ``underthesea[agent]``).
 
 Example
 -------
 ::
 
     from underthesea.agent import Agent, Tool
-    from underthesea.agent.server import serve
+    from underthesea.agent.server import serve  # needs `pip install uvicorn`
 
     def add(a: int, b: int) -> int:
         '''Add two integers.'''
@@ -27,22 +28,20 @@ Example
 
     agent = Agent(name="MathAgent", instruction="...", tools=[Tool(add)])
     serve(agent, port=8000, path="/a2a/math")
+
+To use a different ASGI server::
+
+    from underthesea.agent.server import make_app
+    app = make_app(agent, path="/a2a/math")
+    # then: hypercorn module:app, daphne module:app, etc.
 """
 import asyncio
 import contextvars
 import functools
 import json
 import uuid
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import UTC, datetime
-
-import uvicorn
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.cors import CORSMiddleware
-from starlette.requests import Request
-from starlette.responses import Response, StreamingResponse
-from starlette.routing import Route
 
 from underthesea.agent.agent import Agent
 from underthesea.agent.tools import Tool
@@ -122,6 +121,79 @@ def _sse_event(rpc_id, result: dict) -> bytes:
     return f"data: {json.dumps(payload)}\n\n".encode()
 
 
+# ---------- raw ASGI helpers ----------
+
+
+async def _read_body(receive) -> bytes:
+    body, more = b"", True
+    while more:
+        msg = await receive()
+        body += msg.get("body", b"")
+        more = msg.get("more_body", False)
+    return body
+
+
+async def _send_bytes(
+    send, status: int, body: bytes, content_type: str, extra_headers=()
+) -> None:
+    headers = [
+        (b"content-type", content_type.encode()),
+        (b"content-length", str(len(body)).encode()),
+        *extra_headers,
+    ]
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+async def _send_sse(
+    send, generator: AsyncIterator[bytes], extra_headers=()
+) -> None:
+    headers = [
+        (b"content-type", b"text/event-stream"),
+        (b"cache-control", b"no-cache"),
+        (b"x-accel-buffering", b"no"),
+        *extra_headers,
+    ]
+    await send({"type": "http.response.start", "status": 200, "headers": headers})
+    async for chunk in generator:
+        await send({"type": "http.response.body", "body": chunk, "more_body": True})
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+def _cors_headers(request_origin: str | None, allow_origins: list[str]) -> list:
+    if not allow_origins:
+        return []
+    if "*" in allow_origins:
+        allowed = request_origin or "*"
+    elif request_origin in allow_origins:
+        allowed = request_origin
+    else:
+        return []
+    return [
+        (b"access-control-allow-origin", allowed.encode()),
+        (b"access-control-allow-credentials", b"true"),
+        (b"access-control-allow-methods", b"GET, POST, OPTIONS"),
+        (b"access-control-allow-headers", b"*"),
+    ]
+
+
+def _origin_of(scope) -> str | None:
+    for k, v in scope.get("headers", []):
+        if k == b"origin":
+            return v.decode()
+    return None
+
+
+async def _handle_lifespan(receive, send) -> None:
+    while True:
+        msg = await receive()
+        if msg["type"] == "lifespan.startup":
+            await send({"type": "lifespan.startup.complete"})
+        elif msg["type"] == "lifespan.shutdown":
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+
+
 class _SessionRouter:
     """Maps A2A contextId → spawned Agent; owns the streaming RPC handler."""
 
@@ -134,8 +206,8 @@ class _SessionRouter:
             self._sessions[context_id] = _spawn_session_agent(self._template)
         return self._sessions[context_id]
 
-    async def handle_rpc(self, request: Request) -> Response:
-        body = await request.json()
+    async def handle_rpc(self, receive, send, cors_headers) -> None:
+        body = json.loads(await _read_body(receive))
         rpc_id = body.get("id")
         params = body.get("params", {})
         message = params.get("message", {})
@@ -185,7 +257,13 @@ class _SessionRouter:
                 "status": {"state": "completed", "timestamp": _now_iso()},
             })
 
-        return StreamingResponse(stream(), media_type="text/event-stream")
+        await _send_sse(send, stream(), extra_headers=cors_headers)
+
+
+# ---------- public API ----------
+
+
+ASGIApp = Callable[[dict, Callable[[], Awaitable[dict]], Callable[[dict], Awaitable[None]]], Awaitable[None]]
 
 
 def make_app(
@@ -196,8 +274,12 @@ def make_app(
     host: str = "127.0.0.1",
     port: int = 8000,
     allow_origins: list[str] | None = None,
-) -> Starlette:
-    """Build a Starlette app serving ``agent`` over A2A.
+) -> ASGIApp:
+    """Build a raw ASGI app serving ``agent`` over A2A.
+
+    Returns an async callable ``(scope, receive, send)`` suitable for any
+    ASGI server (uvicorn, hypercorn, daphne) and composable with any ASGI
+    router (Starlette, FastAPI) via Mount.
 
     Parameters
     ----------
@@ -220,24 +302,30 @@ def make_app(
     card_path = f"{path}/.well-known/agent-card.json"
 
     router = _SessionRouter(agent)
+    allow = allow_origins if allow_origins is not None else ["*"]
 
-    async def serve_card(_request: Request) -> Response:
-        return Response(content=card_bytes, media_type="application/json")
+    async def app(scope, receive, send):
+        if scope["type"] == "lifespan":
+            await _handle_lifespan(receive, send)
+            return
+        if scope["type"] != "http":
+            return
 
-    routes = [
-        Route(card_path, serve_card, methods=["GET"]),
-        Route(path, router.handle_rpc, methods=["POST"]),
-    ]
-    middleware = [
-        Middleware(
-            CORSMiddleware,
-            allow_origins=allow_origins or ["*"],
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        ),
-    ]
-    return Starlette(routes=routes, middleware=middleware)
+        cors = _cors_headers(_origin_of(scope), allow)
+        method, p = scope["method"], scope["path"]
+
+        if method == "OPTIONS":
+            await _send_bytes(send, 204, b"", "text/plain", cors)
+            return
+        if method == "GET" and p == card_path:
+            await _send_bytes(send, 200, card_bytes, "application/json", cors)
+            return
+        if method == "POST" and p == path:
+            await router.handle_rpc(receive, send, cors)
+            return
+        await _send_bytes(send, 404, b"Not Found", "text/plain", cors)
+
+    return app
 
 
 def serve(
@@ -251,9 +339,17 @@ def serve(
 ) -> None:
     """Run a blocking uvicorn server hosting ``agent`` over A2A.
 
-    Convenience entrypoint — use :func:`make_app` if you need to attach extra
-    routes (static UI, custom endpoints) before starting the server.
+    Convenience entrypoint — lazy-imports uvicorn. Use :func:`make_app` if you
+    need to mount extra routes (static UI, custom endpoints) or pick a
+    different ASGI server.
     """
+    try:
+        import uvicorn
+    except ImportError as e:
+        raise ImportError(
+            "uvicorn is required for serve(). Install with: pip install uvicorn"
+        ) from e
+
     app = make_app(agent, path=path, agent_card=agent_card, host=host, port=port)
     print(f"{agent.name} listening on http://{host}:{port}")
     print(f"  RPC:  POST  {path}")

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -42,9 +42,12 @@ import json
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import UTC, datetime
+from pathlib import Path
 
 from underthesea.agent.agent import Agent
 from underthesea.agent.tools import Tool
+
+_STATIC_DIR = Path(__file__).parent / "static"
 
 # Tool calls happen deep inside Agent._call_with_tools; a ContextVar lets us
 # observe each call without changing the Agent API.
@@ -274,6 +277,7 @@ def make_app(
     host: str = "127.0.0.1",
     port: int = 8000,
     allow_origins: list[str] | None = None,
+    ui: bool = False,
 ) -> ASGIApp:
     """Build a raw ASGI app serving ``agent`` over A2A.
 
@@ -294,12 +298,18 @@ def make_app(
         Used only to fill the ``url`` field of the auto-generated card.
     allow_origins : list[str], optional
         CORS origins. Defaults to ``["*"]``.
+    ui : bool
+        If True, also serve the bundled chat UI at ``GET {path}/ui``. The page
+        auto-discovers the RPC endpoint from its own URL and reads the agent
+        name from the AgentCard. Default False.
     """
     _wrap_tools_inplace(agent.tools)
 
     card_dict = agent_card or _auto_agent_card(agent, f"http://{host}:{port}{path}")
     card_bytes = json.dumps(card_dict).encode("utf-8")
     card_path = f"{path}/.well-known/agent-card.json"
+    ui_path = f"{path}/ui"
+    ui_bytes = (_STATIC_DIR / "index.html").read_bytes() if ui else None
 
     router = _SessionRouter(agent)
     allow = allow_origins if allow_origins is not None else ["*"]
@@ -323,6 +333,9 @@ def make_app(
         if method == "POST" and p == path:
             await router.handle_rpc(receive, send, cors)
             return
+        if ui_bytes is not None and method == "GET" and p.rstrip("/") == ui_path:
+            await _send_bytes(send, 200, ui_bytes, "text/html; charset=utf-8", cors)
+            return
         await _send_bytes(send, 404, b"Not Found", "text/plain", cors)
 
     return app
@@ -335,13 +348,13 @@ def serve(
     port: int = 8000,
     path: str = "/a2a",
     agent_card: dict | None = None,
+    ui: bool = False,
     log_level: str = "info",
 ) -> None:
     """Run a blocking uvicorn server hosting ``agent`` over A2A.
 
     Convenience entrypoint — lazy-imports uvicorn. Use :func:`make_app` if you
-    need to mount extra routes (static UI, custom endpoints) or pick a
-    different ASGI server.
+    need to mount extra routes or pick a different ASGI server.
     """
     try:
         import uvicorn
@@ -351,8 +364,12 @@ def serve(
             "Install with: pip install 'underthesea[agent-server]'"
         ) from e
 
-    app = make_app(agent, path=path, agent_card=agent_card, host=host, port=port)
+    app = make_app(
+        agent, path=path, agent_card=agent_card, host=host, port=port, ui=ui,
+    )
     print(f"{agent.name} listening on http://{host}:{port}")
     print(f"  RPC:  POST  {path}")
     print(f"  Card: GET   {path}/.well-known/agent-card.json")
+    if ui:
+        print(f"  UI:   GET   {path}/ui")
     uvicorn.run(app, host=host, port=port, log_level=log_level)

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -347,7 +347,8 @@ def serve(
         import uvicorn
     except ImportError as e:
         raise ImportError(
-            "uvicorn is required for serve(). Install with: pip install uvicorn"
+            "uvicorn is required for serve(). "
+            "Install with: pip install 'underthesea[agent-server]'"
         ) from e
 
     app = make_app(agent, path=path, agent_card=agent_card, host=host, port=port)

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -60,7 +60,7 @@ def _record_tool(func: Callable) -> Callable:
         result = func(**kwargs)
         trace = _trace_var.get()
         if trace is not None:
-            trace.append({"tool": func.__name__, "args": kwargs, "result": result})
+            trace.append({"name": func.__name__, "args": kwargs, "result": result})
         return result
     wrapped.__uts_server_wrapped__ = True
     return wrapped

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -1,0 +1,230 @@
+"""A2A-compatible HTTP server for Agent instances.
+
+Wraps an :class:`Agent` so it speaks the A2A protocol — JSON-RPC over HTTP
+with SSE streaming, plus a discoverable AgentCard at
+``{path}/.well-known/agent-card.json``. One :class:`Agent` is spawned per
+A2A ``context_id`` so each conversation keeps its own history.
+
+Requires ``a2a-sdk[http-server]`` (Starlette + sse-starlette).
+
+Example
+-------
+::
+
+    from underthesea.agent import Agent, Tool
+    from underthesea.agent.server import serve
+
+    def add(a: int, b: int) -> int:
+        '''Add two integers.'''
+        return a + b
+
+    agent = Agent(name="MathAgent", instruction="...", tools=[Tool(add)])
+    serve(agent, port=8000, path="/a2a/math")
+
+Use :func:`make_app` instead of :func:`serve` if you need to mount extra
+routes (e.g. a static UI) on the returned Starlette app.
+"""
+import asyncio
+import contextvars
+import functools
+import json
+import uuid
+from collections.abc import Callable
+
+import uvicorn
+from a2a.server.agent_execution.agent_executor import AgentExecutor
+from a2a.server.agent_execution.simple_request_context_builder import (
+    SimpleRequestContextBuilder,
+)
+from a2a.server.apps.jsonrpc.starlette_app import A2AStarletteApplication
+from a2a.server.request_handlers.default_request_handler import DefaultRequestHandler
+from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
+from a2a.server.tasks.task_updater import TaskUpdater
+from a2a.types import AgentCard, Part
+from a2a.utils.parts import get_text_parts
+from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import Response
+from starlette.routing import Route
+
+from underthesea.agent.agent import Agent
+from underthesea.agent.tools import Tool
+
+# Tool calls happen deep inside Agent._call_with_tools; a ContextVar lets us
+# observe each call without changing the Agent API.
+_trace_var: contextvars.ContextVar[list | None] = contextvars.ContextVar(
+    "underthesea_agent_server_trace", default=None
+)
+
+
+def _record_tool(func: Callable) -> Callable:
+    @functools.wraps(func)
+    def wrapped(**kwargs):
+        result = func(**kwargs)
+        trace = _trace_var.get()
+        if trace is not None:
+            trace.append({"tool": func.__name__, "args": kwargs, "result": result})
+        return result
+    wrapped.__uts_server_wrapped__ = True
+    return wrapped
+
+
+def _wrap_tools_inplace(tools: list[Tool]) -> None:
+    for tool in tools:
+        if not getattr(tool.func, "__uts_server_wrapped__", False):
+            tool.func = _record_tool(tool.func)
+
+
+def _spawn_session_agent(template: Agent) -> Agent:
+    """Fresh Agent sharing the template's tools/instruction/provider, isolated history."""
+    return Agent(
+        name=template.name,
+        tools=template.tools,
+        instruction=template.instruction,
+        max_iterations=template.max_iterations,
+        provider=template._provider,
+        tracer=template._tracer,
+    )
+
+
+def _auto_agent_card(agent: Agent, url: str) -> dict:
+    return {
+        "name": agent.name,
+        "description": (agent.instruction or "")[:200],
+        "url": url,
+        "preferredTransport": "JSONRPC",
+        "protocolVersion": "0.3.0",
+        "version": "1.0.0",
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "capabilities": {
+            "streaming": True,
+            "pushNotifications": False,
+            "stateTransitionHistory": False,
+        },
+        "skills": [
+            {"id": t.name, "name": t.name, "description": t.description}
+            for t in agent.tools
+        ],
+    }
+
+
+class _SessionAgentExecutor(AgentExecutor):
+    """A2A executor that spawns one Agent per A2A ``context_id``."""
+
+    def __init__(self, template: Agent):
+        self._template = template
+        self._sessions: dict[str, Agent] = {}
+
+    async def execute(self, context, event_queue) -> None:
+        updater = TaskUpdater(
+            event_queue,
+            task_id=context.task_id or str(uuid.uuid4()),
+            context_id=context.context_id or str(uuid.uuid4()),
+        )
+        await updater.submit()
+        await updater.start_work()
+
+        text_parts = get_text_parts(context.message.parts if context.message else [])
+        user_message = (text_parts[0] if text_parts else "").strip()
+
+        agent = self._sessions.setdefault(
+            updater.context_id, _spawn_session_agent(self._template)
+        )
+        trace: list[dict] = []
+        token = _trace_var.set(trace)
+        try:
+            reply = await asyncio.to_thread(agent, user_message)
+        finally:
+            _trace_var.reset(token)
+
+        for step in trace:
+            await updater.add_artifact(
+                [Part.model_validate(
+                    {"kind": "data", "data": {"tool_call": step}}
+                )],
+                name="tool_call",
+            )
+        await updater.add_artifact(
+            [Part.model_validate({"kind": "text", "text": reply})],
+            name="reply",
+        )
+        await updater.complete()
+
+    async def cancel(self, context, event_queue) -> None:
+        pass
+
+
+def make_app(
+    agent: Agent,
+    *,
+    path: str,
+    agent_card: dict | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    allow_origins: list[str] | None = None,
+):
+    """Build a Starlette ASGI app serving ``agent`` over A2A.
+
+    Parameters
+    ----------
+    agent : Agent
+        Template agent; per-session copies are spawned to isolate history.
+    path : str
+        JSON-RPC endpoint, e.g. ``"/a2a/my_agent"``. The agent card is mounted
+        at ``f"{path}/.well-known/agent-card.json"``.
+    agent_card : dict, optional
+        Override the auto-generated AgentCard.
+    host, port : str, int
+        Used only to fill the ``url`` field of the auto-generated card.
+    allow_origins : list[str], optional
+        CORS origins. Defaults to ``["*"]``.
+    """
+    _wrap_tools_inplace(agent.tools)
+
+    card_dict = agent_card or _auto_agent_card(agent, f"http://{host}:{port}{path}")
+    card_bytes = json.dumps(card_dict).encode("utf-8")
+    card_path = f"{path}/.well-known/agent-card.json"
+
+    async def serve_card(_request):
+        return Response(content=card_bytes, media_type="application/json")
+
+    handler = DefaultRequestHandler(
+        agent_executor=_SessionAgentExecutor(agent),
+        task_store=InMemoryTaskStore(),
+        request_context_builder=SimpleRequestContextBuilder(),
+    )
+    app = A2AStarletteApplication(
+        agent_card=AgentCard.model_validate(card_dict),
+        http_handler=handler,
+    ).build(rpc_url=path, agent_card_url=card_path)
+    # Ours wins because Starlette uses first-match routing.
+    app.routes.insert(0, Route(card_path, serve_card, methods=["GET"]))
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allow_origins or ["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return app
+
+
+def serve(
+    agent: Agent,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/a2a",
+    agent_card: dict | None = None,
+    log_level: str = "info",
+):
+    """Run a blocking uvicorn server hosting ``agent`` over A2A.
+
+    Convenience entrypoint — use :func:`make_app` if you need to attach extra
+    routes (static UI, custom endpoints) before starting the server.
+    """
+    app = make_app(agent, path=path, agent_card=agent_card, host=host, port=port)
+    print(f"{agent.name} listening on http://{host}:{port}")
+    print(f"  RPC:  POST  {path}")
+    print(f"  Card: GET   {path}/.well-known/agent-card.json")
+    uvicorn.run(app, host=host, port=port, log_level=log_level)

--- a/underthesea/agent/server.py
+++ b/underthesea/agent/server.py
@@ -102,7 +102,7 @@ def _auto_agent_card(agent: Agent, url: str) -> dict:
             "stateTransitionHistory": False,
         },
         "skills": [
-            {"id": t.name, "name": t.name, "description": t.description}
+            {"id": t.name, "name": t.name, "description": t.description, "tags": []}
             for t in agent.tools
         ],
     }
@@ -127,9 +127,9 @@ class _SessionAgentExecutor(AgentExecutor):
         text_parts = get_text_parts(context.message.parts if context.message else [])
         user_message = (text_parts[0] if text_parts else "").strip()
 
-        agent = self._sessions.setdefault(
-            updater.context_id, _spawn_session_agent(self._template)
-        )
+        if updater.context_id not in self._sessions:
+            self._sessions[updater.context_id] = _spawn_session_agent(self._template)
+        agent = self._sessions[updater.context_id]
         trace: list[dict] = []
         token = _trace_var.set(trace)
         try:

--- a/underthesea/agent/static/index.html
+++ b/underthesea/agent/static/index.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>A2A Agent</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #181b22; --border: #262a33;
+    --text: #e8ecef; --muted: #8a93a6;
+    --user: #2b6cb0; --bot: #2d3748;
+    --tool: #1f2a1f; --tool-border: #3c5a3c; --accent: #4ade80;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--text);
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  .wrap { max-width: 760px; margin: 0 auto; height: 100vh; display: flex; flex-direction: column; }
+  header { padding: 14px 20px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; }
+  header h1 { margin: 0; font-size: 16px; font-weight: 600; }
+  header .meta { font-size: 11px; color: var(--muted); font-family: ui-monospace, monospace; }
+  header button { background: transparent; color: var(--muted); border: 1px solid var(--border);
+    padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 13px; margin-left: 8px; }
+  header button:hover { color: var(--text); border-color: var(--muted); }
+  #log { flex: 1; overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 12px; }
+  .msg { padding: 10px 14px; border-radius: 12px; max-width: 80%; white-space: pre-wrap; word-wrap: break-word; }
+  .msg.user { background: var(--user); align-self: flex-end; border-bottom-right-radius: 4px; }
+  .msg.bot { background: var(--bot); align-self: flex-start; border-bottom-left-radius: 4px; }
+  .tool { align-self: flex-start; max-width: 80%; background: var(--tool); border: 1px solid var(--tool-border);
+    border-radius: 8px; padding: 8px 12px; font-size: 12px; color: var(--muted); font-family: ui-monospace, "SF Mono", monospace; }
+  .tool b { color: var(--accent); }
+  .tool pre { margin: 4px 0 0; white-space: pre-wrap; word-break: break-all; }
+  .status { align-self: flex-start; font-size: 11px; color: var(--muted); font-style: italic; }
+  form { display: flex; gap: 8px; padding: 14px 20px; border-top: 1px solid var(--border); }
+  input { flex: 1; background: var(--panel); border: 1px solid var(--border); color: var(--text);
+    padding: 10px 14px; border-radius: 8px; font-size: 14px; outline: none; }
+  input:focus { border-color: var(--accent); }
+  button[type=submit] { background: var(--accent); color: #0f1115; border: none; padding: 10px 18px;
+    border-radius: 8px; cursor: pointer; font-weight: 600; }
+  button[type=submit]:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div>
+      <h1 id="title">A2A Agent</h1>
+      <div class="meta">A2A · JSON-RPC · message/stream</div>
+    </div>
+    <div>
+      <button id="card-btn">View agent card</button>
+      <button id="reset-btn">Reset</button>
+    </div>
+  </header>
+  <div id="log"></div>
+  <form id="form">
+    <input id="input" autocomplete="off" placeholder="Type a message…" autofocus>
+    <button type="submit" id="send">Send</button>
+  </form>
+</div>
+
+<script>
+// UI is served at `{RPC_URL}/ui` (or `{RPC_URL}/ui/`). Strip the trailing
+// `/ui` segment to recover the JSON-RPC endpoint, then hit the well-known
+// AgentCard to populate the title.
+const RPC_URL = window.location.pathname.replace(/\/ui\/?$/, "");
+const CARD_URL = `${RPC_URL}/.well-known/agent-card.json`;
+
+const SESSION_KEY = `a2a_session:${RPC_URL}`;
+let contextId = localStorage.getItem(SESSION_KEY);
+if (!contextId) {
+  contextId = crypto.randomUUID();
+  localStorage.setItem(SESSION_KEY, contextId);
+}
+
+const log = document.getElementById("log");
+const form = document.getElementById("form");
+const input = document.getElementById("input");
+const send = document.getElementById("send");
+const resetBtn = document.getElementById("reset-btn");
+const cardBtn = document.getElementById("card-btn");
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+}
+
+function addMsg(role, text) {
+  const el = document.createElement("div");
+  el.className = `msg ${role}`;
+  el.textContent = text;
+  log.appendChild(el);
+  log.scrollTop = log.scrollHeight;
+  return el;
+}
+
+function addTool(data) {
+  const tc = data.tool_call;
+  const el = document.createElement("div");
+  el.className = "tool";
+  el.innerHTML = `<b>tool ${esc(tc.name)}</b>(${esc(JSON.stringify(tc.args))})<pre>${esc(JSON.stringify(tc.result, null, 2))}</pre>`;
+  log.appendChild(el);
+  log.scrollTop = log.scrollHeight;
+}
+
+function addStatus(text) {
+  const el = document.createElement("div");
+  el.className = "status";
+  el.textContent = text;
+  log.appendChild(el);
+  log.scrollTop = log.scrollHeight;
+  return el;
+}
+
+async function* sseStream(response) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      try { yield JSON.parse(line.slice(6)); } catch (e) {}
+    }
+  }
+}
+
+form.addEventListener("submit", async e => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  addMsg("user", text);
+  input.value = "";
+  send.disabled = true;
+  const typing = addStatus("đang xử lý...");
+
+  const rpcReq = {
+    jsonrpc: "2.0",
+    id: crypto.randomUUID(),
+    method: "message/stream",
+    params: {
+      message: {
+        role: "user",
+        parts: [{ kind: "text", text }],
+        messageId: crypto.randomUUID(),
+        contextId,
+      },
+      configuration: { historyLength: 20 },
+      metadata: { sessionId: contextId },
+    },
+  };
+
+  try {
+    const r = await fetch(RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+      body: JSON.stringify(rpcReq),
+    });
+    if (!r.ok) throw new Error(`HTTP ${r.status}: ${await r.text()}`);
+    typing.remove();
+
+    let replyEl = null;
+    for await (const msg of sseStream(r)) {
+      const result = msg.result;
+      if (!result) {
+        if (msg.error) addMsg("bot", "RPC error: " + JSON.stringify(msg.error));
+        continue;
+      }
+      if (result.kind === "status-update" || result.status) {
+        const state = result.status?.state ?? result.state;
+        if (state && state !== "working" && state !== "submitted") {
+          addStatus(`status: ${state}`);
+        }
+      }
+      if (result.kind === "artifact-update" || result.artifact) {
+        const artifact = result.artifact ?? result;
+        for (const part of artifact.parts || []) {
+          if (part.kind === "data" || part.data) {
+            addTool(part.data);
+          } else if (part.kind === "text" || part.text) {
+            if (!replyEl) replyEl = addMsg("bot", "");
+            replyEl.textContent += part.text;
+          }
+        }
+      }
+    }
+    if (!replyEl) addMsg("bot", "(không có phản hồi)");
+  } catch (err) {
+    typing.remove();
+    addMsg("bot", "Lỗi: " + err.message);
+  } finally {
+    send.disabled = false;
+    input.focus();
+  }
+});
+
+resetBtn.addEventListener("click", () => {
+  contextId = crypto.randomUUID();
+  localStorage.setItem(SESSION_KEY, contextId);
+  log.innerHTML = "";
+  addStatus("context reset");
+});
+
+// Populate title/heading from the agent's published card.
+fetch(CARD_URL).then(r => r.json()).then(card => {
+  if (card?.name) {
+    document.title = `${card.name} (A2A)`;
+    document.getElementById("title").textContent = card.name;
+  }
+}).catch(() => {});
+
+cardBtn.addEventListener("click", async () => {
+  const r = await fetch(CARD_URL);
+  const card = await r.json();
+  const el = document.createElement("div");
+  el.className = "tool";
+  el.innerHTML = `<b>agent card</b><pre>${esc(JSON.stringify(card, null, 2))}</pre>`;
+  log.appendChild(el);
+  log.scrollTop = log.scrollHeight;
+});
+</script>
+</body>
+</html>

--- a/underthesea/agent/static/index.html
+++ b/underthesea/agent/static/index.html
@@ -36,6 +36,17 @@
   button[type=submit] { background: var(--accent); color: #0f1115; border: none; padding: 10px 18px;
     border-radius: 8px; cursor: pointer; font-weight: 600; }
   button[type=submit]:disabled { opacity: 0.5; cursor: not-allowed; }
+  .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: none;
+    align-items: center; justify-content: center; z-index: 10; }
+  .modal-backdrop.open { display: flex; }
+  .modal { background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+    max-width: 720px; max-height: 80vh; width: calc(100% - 40px); display: flex; flex-direction: column; }
+  .modal header { padding: 14px 20px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+  .modal header h2 { margin: 0; font-size: 15px; font-weight: 600; }
+  .modal header .close { background: transparent; color: var(--muted); border: none; cursor: pointer; font-size: 20px; line-height: 1; padding: 0 4px; }
+  .modal header .close:hover { color: var(--text); }
+  .modal pre { margin: 0; padding: 16px 20px; overflow: auto; font-family: ui-monospace, "SF Mono", monospace;
+    font-size: 12px; color: var(--text); white-space: pre-wrap; word-break: break-all; }
 </style>
 </head>
 <body>
@@ -43,7 +54,6 @@
   <header>
     <div>
       <h1 id="title">A2A Agent</h1>
-      <div class="meta">A2A · JSON-RPC · message/stream</div>
     </div>
     <div>
       <button id="card-btn">View agent card</button>
@@ -55,6 +65,16 @@
     <input id="input" autocomplete="off" placeholder="Type a message…" autofocus>
     <button type="submit" id="send">Send</button>
   </form>
+</div>
+
+<div id="modal-backdrop" class="modal-backdrop">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <header>
+      <h2 id="modal-title">Agent card</h2>
+      <button class="close" id="modal-close" aria-label="Close">×</button>
+    </header>
+    <pre id="modal-body"></pre>
+  </div>
 </div>
 
 <script>
@@ -77,6 +97,24 @@ const input = document.getElementById("input");
 const send = document.getElementById("send");
 const resetBtn = document.getElementById("reset-btn");
 const cardBtn = document.getElementById("card-btn");
+const modalBackdrop = document.getElementById("modal-backdrop");
+const modalBody = document.getElementById("modal-body");
+const modalClose = document.getElementById("modal-close");
+
+function openModal(jsonText) {
+  modalBody.textContent = jsonText;
+  modalBackdrop.classList.add("open");
+}
+function closeModal() {
+  modalBackdrop.classList.remove("open");
+}
+modalClose.addEventListener("click", closeModal);
+modalBackdrop.addEventListener("click", e => {
+  if (e.target === modalBackdrop) closeModal();
+});
+document.addEventListener("keydown", e => {
+  if (e.key === "Escape") closeModal();
+});
 
 function esc(s) {
   return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
@@ -211,13 +249,12 @@ fetch(CARD_URL).then(r => r.json()).then(card => {
 }).catch(() => {});
 
 cardBtn.addEventListener("click", async () => {
-  const r = await fetch(CARD_URL);
-  const card = await r.json();
-  const el = document.createElement("div");
-  el.className = "tool";
-  el.innerHTML = `<b>agent card</b><pre>${esc(JSON.stringify(card, null, 2))}</pre>`;
-  log.appendChild(el);
-  log.scrollTop = log.scrollHeight;
+  try {
+    const r = await fetch(CARD_URL);
+    openModal(JSON.stringify(await r.json(), null, 2));
+  } catch (err) {
+    openModal(`Failed to fetch agent card:\n${err.message}`);
+  }
 });
 </script>
 </body>

--- a/underthesea/agent/wiki.py
+++ b/underthesea/agent/wiki.py
@@ -25,7 +25,6 @@ Usage:
 """
 
 import json
-import os
 import re
 import urllib.parse
 import urllib.request
@@ -579,7 +578,7 @@ class WikiAgent:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
         except Exception as e:
-            raise RuntimeError(f"Failed to fetch tweet: {e}")
+            raise RuntimeError(f"Failed to fetch tweet: {e}") from e
 
         tweet = data.get("tweet", {})
         author = tweet.get("author", {})
@@ -664,7 +663,7 @@ class WikiAgent:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 html = resp.read().decode("utf-8", errors="ignore")
         except Exception as e:
-            raise RuntimeError(f"Failed to fetch {url}: {e}")
+            raise RuntimeError(f"Failed to fetch {url}: {e}") from e
 
         # Extract title
         title_match = re.search(r"<title[^>]*>(.*?)</title>", html, re.DOTALL | re.IGNORECASE)


### PR DESCRIPTION
## Summary
- Adds `underthesea/agent/server.py` exposing `serve(agent, ...)` and `make_app(agent, ...)` — any `Agent` becomes an A2A-protocol HTTP service (JSON-RPC + SSE) with a discoverable `AgentCard` at `/.well-known/agent-card.json`.
- One `Agent` is spawned per A2A `context_id` (shares tools/instruction/provider with the template, isolated history) so multi-turn conversations stay coherent without cross-session bleed.
- Tool calls are streamed live as `tool_call` artifacts via a ContextVar-based wrapper around each `Tool.func` — the `Agent` class itself is not modified.
- Sync `Agent.__call__` is offloaded via `asyncio.to_thread`, keeping the server's event loop responsive.

## Usage

```python
from underthesea.agent import Agent, Tool
from underthesea.agent.server import serve

def add(a: int, b: int) -> int:
    """Add two integers."""
    return a + b

agent = Agent(name="MathAgent", instruction="...", tools=[Tool(add)])
serve(agent, port=8000, path="/a2a/math")
```

For mounting extra routes (custom UI, static files), use `make_app(...)` which returns the Starlette app.

## Dependencies
- Requires `a2a-sdk[http-server]` (Starlette + sse-starlette + uvicorn) at runtime.
- Opt-in module: `agent/__init__.py` does not import `server.py`, so the rest of `underthesea.agent` works without the new dep.

## Test plan
- [ ] Smoke: `from underthesea.agent.server import serve, make_app` imports cleanly
- [ ] Spin up `serve(agent, port=8000, path="/a2a/test")` and `curl GET /a2a/test/.well-known/agent-card.json`
- [ ] `POST /a2a/test` with JSON-RPC `message/stream` returns SSE stream with `status-update` and `artifact-update` events
- [ ] Multi-turn: send 2 messages with same `contextId` and confirm second call reuses prior tool results without re-running the search tool
- [ ] Verify no a2a-sdk import happens for `from underthesea.agent import Agent` (the module is opt-in)