### PR TITLE
Release version 9.5.0

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.5.0] - 2026-05-17
+
 ### Added
 
 - A2A-compatible HTTP server adapter `underthesea.agent.server` ([#1016](https://github.com/undertheseanlp/underthesea/pull/1016))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "underthesea"
-version = "9.4.0"
+version = "9.5.0"
 description = "Vietnamese NLP Toolkit"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump version 9.4.0 → 9.5.0 and close the `[Unreleased]` section in the changelog.

## Highlights for 9.5.0

- **A2A-compatible HTTP server adapter** (`underthesea.agent.server`) — `make_app()` returns a raw ASGI callable (no web framework dep), `serve(agent, ui=True)` spins up uvicorn with a bundled chat UI. JSON-RPC `message/stream` over SSE + discoverable `AgentCard` ([#1016](https://github.com/undertheseanlp/underthesea/pull/1016))
- New `[agent-server]` extra (uvicorn + starlette + httpx, ADK-aligned version ranges)
- 17 server tests via `httpx.ASGITransport` + new `ci-agent` workflow
- Fixed pre-existing ruff issues in `agent/wiki.py` that blocked CI

See `docs/docs/changelog.md` `[9.5.0]` section for details.

## Test plan

- [x] `pyproject.toml` bumped to `9.5.0`
- [x] Changelog `[Unreleased]` entries moved under `[9.5.0] - 2026-05-17`
- [ ] CI green (lint, tests, ci-agent, ci-prompt, ci-tts, ci-langdetect, ci-train-*, ci-windows, ci-deep, snyk)