### PR TITLE
docs(research): add personal AI OS research notes

### DIFF
--- a/docs/research/personal-ai-os/01-design.md
+++ b/docs/research/personal-ai-os/01-design.md
@@ -1,0 +1,118 @@
+# Personal AI OS — Design Document
+
+> Last updated: 2026-05-17
+
+## 1. Problem
+
+Hầu hết "agent framework" hiện nay (LangGraph, CrewAI, AutoGen) thiết kế cho **dev xây enterprise pipeline** — mỗi lần dùng phải:
+
+1. Viết Python code, deploy lên server
+2. Trigger qua HTTP request hoặc CLI
+3. Agent chạy xong → tắt, mất state
+
+Đây không phải cách end-user dùng AI hàng ngày. Một **personal assistant thực sự** cần:
+
+- **Always-on** — nghe inbox, message, calendar 24/7
+- **Multi-channel** — WhatsApp, iMessage, Slack, Telegram cùng lúc
+- **Multi-device** — laptop, phone, tablet đều là endpoint
+- **Persistent memory** — nhớ context xuyên qua phiên/ngày/tuần
+- **Proactive** — tự action khi có trigger, không chờ user prompt
+
+Trend này có tên: **Personal AI OS** (hoặc Ambient Agent, Always-on Agent). OpenClaw là reference implementation viral nhất 2026.
+
+## 2. Đặc trưng của Personal AI OS
+
+### 2.1 Daemon-first, không request-response
+
+- Long-lived process, mở socket nghe events
+- Khác với CLI agent (Claude Code, Gemini CLI): chạy → trả → tắt
+- Khác với chat UI (ChatGPT): user phải mở app, gõ prompt
+
+### 2.2 Gateway pattern
+
+Một **Gateway** duy nhất làm:
+- Message broker giữa channel ↔ agent
+- Session/device pairing + auth
+- Event bus (chat, presence, health, schedule)
+- Wire protocol (WebSocket + JSON Schema)
+
+### 2.3 Memory-first, không stateless
+
+- Persistent context (Markdown files / structured store)
+- Cross-session handoff
+- Shared memory giữa các sub-agent
+
+### 2.4 Ambient triggers (Heartbeat)
+
+- Cron-like scheduler nội bộ
+- Mailbox/inbox watcher
+- File system / app event listener
+- "Khi X xảy ra → agent action Y" thay vì "user hỏi → agent trả"
+
+### 2.5 Multi-device mesh
+
+- Mỗi device (laptop/phone/headless) là **Node**
+- Nodes expose capabilities: camera, screen, mic, location, canvas
+- Gateway route action tới Node phù hợp
+
+### 2.6 Reliability patterns
+
+- **Lane Queue** — serial-by-default cho side-effect (gửi tin nhắn, ghi file)
+- **Semantic Snapshot** — accessibility tree thay vì HTML thô
+- Idempotent action retry
+
+## 3. Architecture (reference: OpenClaw)
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Channels: WhatsApp / iMessage / Slack / Telegram   │
+└───────────────────────┬─────────────────────────────┘
+                        │
+              ┌─────────▼──────────┐
+              │   Gateway daemon   │ ← WS + JSON Schema, auth, pairing
+              │   (lane queue)     │
+              └─────────┬──────────┘
+                        │
+              ┌─────────▼──────────┐
+              │  Orchestrator      │ ← routes to specialized agent
+              │  + Agent Runtime   │
+              └─────────┬──────────┘
+                        │
+        ┌───────────────┼────────────────┐
+        │               │                │
+  ┌─────▼────┐   ┌──────▼─────┐   ┌──────▼─────┐
+  │ Skills   │   │ Memory     │   │ Heartbeat  │
+  │ (tools)  │   │ (Markdown) │   │ (schedule) │
+  └─────┬────┘   └────────────┘   └────────────┘
+        │
+  ┌─────▼──────────────────────────────────────┐
+  │  Nodes (macOS / iOS / Android / headless)  │
+  │  → camera, screen, canvas, location, mic   │
+  └────────────────────────────────────────────┘
+```
+
+## 4. So với Underthesea Agent hiện tại
+
+| Layer | Underthesea (current) | Personal AI OS target |
+|---|---|---|
+| Entry | Sync Python call | WebSocket daemon |
+| Channels | Stdin/CLI | WhatsApp, Slack, ... |
+| Memory | History list + Handoff JSON | Markdown shared store |
+| Trigger | User prompt | Inbox watcher + cron |
+| Devices | Single process | Node mesh |
+| Reliability | None | Lane queue, semantic snapshot |
+| Multi-agent | Single agent | Orchestrator + specialized agents |
+
+Underthesea hiện ở **Layer 1 (SDK)** — nếu muốn lên Personal AI OS phải thêm Gateway + Heartbeat + Node protocol.
+
+## 5. Non-goals (cho Underthesea)
+
+- **Không** clone toàn bộ OpenClaw — quá nặng cho mục tiêu NLP library
+- **Không** target end-user; vẫn target developer
+- **Có thể** mượn patterns chọn lọc: lane queue, ambient trigger, markdown memory (đã có trong `WikiAgent`)
+
+## 6. Open questions
+
+1. Có nên tách `underthesea.agent` thành package độc lập để target Personal AI OS không?
+2. Vietnamese-specific channels nào quan trọng (Zalo, Lotus)?
+3. Self-hosted vs cloud trade-off cho user Việt Nam?

--- a/docs/research/personal-ai-os/02-research.md
+++ b/docs/research/personal-ai-os/02-research.md
@@ -1,0 +1,122 @@
+# Personal AI OS — Research
+
+> Last updated: 2026-05-17
+
+## 1. Trend overview
+
+Personal AI OS là sự hội tụ của 4 trend agentic AI nổi bật trong 2024-2026:
+
+### 1.1 Always-on / Ambient agents
+- Khái niệm "ambient agents" được Harrison Chase (LangChain CEO) phổ biến 2025
+- Agent **chủ động** monitor inbox/event, không chờ user prompt
+- Đối lập với "reactive chatbot"
+
+### 1.2 Personal AI OS (self-hosted)
+- Phong trào "own your AI" — không lệ thuộc cloud của OpenAI/Anthropic
+- Driven by privacy concerns + cost của subscription
+- Mở đường cho Ollama, LocalAI, OpenClaw
+
+### 1.3 Memory-first architecture
+- Mem0, Letta (MemGPT), Cognee
+- Karpathy 2025: "wiki as personal memory" — markdown human-readable
+- Khác hướng vector DB-only
+
+### 1.4 Multi-channel / Multi-device
+- Apple Intelligence (cross-device, on-device)
+- Humane AI Pin, Rabbit R1 (dedicated device, không cần phone)
+- OpenClaw: open-source version của ý tưởng này
+
+## 2. Landscape (2026)
+
+### 2.1 Personal AI OS / Always-on
+| Project | License | Notes |
+|---|---|---|
+| **OpenClaw** | MIT | Viral 2026, 347k ⭐, multi-channel daemon |
+| **Open Interpreter** | AGPL | Earlier, code execution focus |
+| **Letta (MemGPT)** | Apache | Memory-first, less channel coverage |
+| **Pieces OS** | Closed | Code-snippet focused, on-device |
+| **Cluely** | Closed | Screen + audio ambient |
+| **Rewind** | Closed | macOS recall, on-device |
+
+### 2.2 Memory layer (có thể plug vào Personal AI OS)
+| Project | Approach |
+|---|---|
+| **Mem0** | Long-term memory với vector + graph |
+| **Letta** | Tiered memory (in-context + recall) |
+| **Cognee** | Knowledge graph memory |
+| **Karpathy wiki** | Plain markdown, LLM-maintained |
+
+### 2.3 Multi-agent frameworks (developer-facing — KHÁC layer)
+- LangGraph, CrewAI, AutoGen: enterprise pipeline
+- KHÔNG phải Personal AI OS — chúng là building block để xây Personal AI OS
+
+## 3. Key technical patterns
+
+### 3.1 Gateway pattern (OpenClaw)
+- 1 daemon owns tất cả messaging surface
+- WebSocket + JSON Schema validation
+- Device pairing trước khi cấp token
+- Phù hợp với mental model "OS service"
+
+### 3.2 Lane Queue
+- Serial-by-default cho action có side-effect
+- Tránh race: 2 tin nhắn cùng lúc, 2 file write cùng lúc
+- Có "express lane" cho read-only
+
+### 3.3 Semantic Snapshot (web browsing)
+- Parse accessibility tree thay vì HTML/screenshot
+- Giảm 10-20x token vs raw HTML
+- Tăng accuracy với screen reader semantics
+- Tham khảo: Browser Use, Playwright accessibility snapshot
+
+### 3.4 Heartbeat / proactive triggers
+- Cron scheduler nội bộ
+- Inbox watcher (IMAP/Gmail API/Slack RTM)
+- Filesystem watcher
+- Webhook receiver
+
+### 3.5 Memory as Markdown
+- Karpathy thesis: vector DB là premature optimization cho personal scale
+- Markdown: human-readable, git-friendly, grep-able, LLM-native
+- Trade-off: kém scale hơn vector cho > 10k docs
+
+### 3.6 Node mesh
+- gRPC / WebSocket node-to-gateway
+- Capability advertisement (camera, screen, location...)
+- Trust model: pairing + device token
+
+## 4. Caveats & open problems
+
+### 4.1 Privacy vs convenience
+- Self-hosted = không có cloud nhưng yêu cầu maintenance
+- Multi-channel listener = cần credentials cho mọi service → attack surface lớn
+
+### 4.2 Cost
+- LLM call cho ambient agent có thể nổ chi phí
+- Heartbeat mỗi 5 phút × 24h × 30 ngày = 8640 call/tháng
+- Cần model local (Ollama) hoặc small model (Haiku) cho background task
+
+### 4.3 Reliability
+- Long-running daemon dễ bị memory leak, hang
+- Cần process supervisor (systemd, launchd)
+- State recovery sau crash
+
+### 4.4 Trigger explosion
+- Quá nhiều inbox watcher → noise
+- Cần rate limit + dedup pattern
+
+### 4.5 Vietnamese context
+- Channel chính: Zalo (API hạn chế), Facebook Messenger
+- Email tiếng Việt cần segmentation/normalization (đây là điểm Underthesea có thể mạnh)
+- Voice (TTS/STT) tiếng Việt vẫn yếu so với English
+
+## 5. References
+
+- [OpenClaw architecture docs](https://docs.openclaw.ai/concepts/architecture)
+- [OpenClaw April 2026 update](https://www.clawbot.blog/blog/openclaw-the-rise-of-an-open-source-ai-agent-framework-april-2026-update/)
+- [Reference Architecture: OpenClaw (Feb 2026)](https://robotpaper.ai/reference-architecture-openclaw-early-feb-2026-edition-opus-4-6/)
+- [Lessons from OpenClaw's Architecture - Agentailor](https://blog.agentailor.com/posts/openclaw-architecture-lessons-for-agent-builders)
+- [Harrison Chase on Ambient Agents (LangChain blog)](https://blog.langchain.dev) — concept origin
+- [Karpathy: building a personal wiki with LLM](https://karpathy.ai) — markdown memory thesis
+- [Mem0 GitHub](https://github.com/mem0ai/mem0)
+- [Letta (MemGPT) GitHub](https://github.com/letta-ai/letta)

--- a/docs/research/personal-ai-os/03-examples.md
+++ b/docs/research/personal-ai-os/03-examples.md
@@ -1,0 +1,155 @@
+# Personal AI OS — Examples
+
+> Last updated: 2026-05-17
+
+Các ví dụ minh hoạ cách Personal AI OS hoạt động khác với CLI agent / chatbot truyền thống.
+
+## Example 1: Email triage 24/7 (Ambient)
+
+### Chatbot truyền thống
+```
+User: "Đọc inbox và summarize giúp tôi"
+Bot:  [đọc 50 mail, trả về summary]
+User đóng app → bot ngừng.
+```
+
+### Personal AI OS
+```
+[Daemon chạy nền]
+07:00 - Heartbeat fires: "check inbox"
+      - Email watcher tìm mail mới: 3 mail
+      - Email triage agent phân loại: 1 urgent, 2 newsletter
+      - Push notification: "Anh ơi, có 1 mail urgent từ sếp về Q2 planning"
+07:05 - User reply trong notification: "Draft phản hồi"
+      - Agent draft → user approve → send qua Gmail API
+```
+
+Khác biệt: agent **chủ động trigger**, user chỉ đóng vai quyết định.
+
+## Example 2: Multi-channel context handoff
+
+```
+[10:00 Slack] Sếp: "Em chuẩn bị deck cho meeting 14:00 nhé"
+              → Agent ghi nhận task vào Memory
+              
+[12:30 iMessage] Bạn: "Đi cafe không?"
+              → Agent nhắc user: "Bạn có deck cần xong trước 14:00"
+
+[13:00 WhatsApp] Vợ: "Mua sữa về"
+              → Agent gộp vào shopping list, nhắc 18:00
+              
+[13:55] Heartbeat: "deck đã xong chưa?"
+              → Check folder ./decks/Q2.pptx → exists, modified 13:50
+              → Push: "Deck OK, sẵn sàng meeting"
+```
+
+Channel khác nhau, agent vẫn maintain **một shared memory**.
+
+## Example 3: Multi-device delegation
+
+```
+User (laptop): "Chụp ảnh whiteboard rồi gửi vào group"
+              ↓
+   Gateway nhận, parse intent
+              ↓
+   Orchestrator: "cần camera + Slack send"
+              ↓
+   ├── Node[iPhone]: capability=camera → chụp ảnh
+   └── Node[laptop]: capability=slack_api → upload + gửi
+```
+
+Mỗi device là 1 node, gateway route theo capability.
+
+## Example 4: Lane Queue protecting side-effects
+
+```python
+# Nếu KHÔNG có lane queue (parallel tool call):
+agent: "Tôi sẽ gửi xác nhận"
+  → tool: send_message("OK") | send_message("Đã nhận") | send_message("Cảm ơn")
+  → User nhận 3 tin nhắn cùng lúc, có thể lệch thứ tự
+
+# Với Lane Queue (serial-by-default cho channel 'messaging'):
+agent: "Tôi sẽ gửi xác nhận"
+  → lane[messaging]: send_message("OK") → wait → send_message("Đã nhận") → wait → ...
+  → User nhận đúng 1 tin cuối cùng (agent thấy duplicate, dedupe).
+```
+
+## Example 5: Semantic Snapshot cho web
+
+```python
+# Approach cũ - raw HTML:
+html = fetch_url("https://booking.com/search?...")
+# → 200 KB HTML, ~50k tokens
+# → LLM phải parse div/span lồng nhau, dễ lạc
+
+# Semantic Snapshot:
+snapshot = accessibility_tree(page)
+# → 8 KB
+# → cấu trúc:
+#   - role=heading "Hotels in Hanoi"
+#   - role=listbox
+#     - role=option "Hilton Hanoi - $120/night - 4.5 stars"
+#     - role=option "Sofitel Legend - $250/night - 4.8 stars"
+# → LLM hiểu ngay, ít token, accuracy cao
+```
+
+## Example 6: Memory-as-Markdown (Karpathy style)
+
+```
+my-personal-os/
+├── memory/
+│   ├── people/
+│   │   ├── boss-mr-nam.md      # "Thích deck dạng minimal, không bullet point"
+│   │   └── wife-linh.md         # "Birthday 15/8, thích trà đào"
+│   ├── projects/
+│   │   ├── uts1-roadmap.md
+│   │   └── q2-planning.md
+│   └── habits/
+│       └── morning-routine.md
+├── inbox/                       # raw mail dump
+└── digest/                      # daily summary do agent tạo
+```
+
+Agent **đọc/ghi markdown trực tiếp**. User cũng đọc/ghi được bằng editor. Git diff thấy agent đã thay đổi gì.
+
+## Example 7: Heartbeat triggers
+
+```yaml
+# heartbeat.yml — schedule + trigger config
+triggers:
+  - name: morning_brief
+    cron: "0 7 * * *"          # 7AM mỗi ngày
+    action: agent.run("Tóm tắt inbox + calendar hôm nay")
+    
+  - name: urgent_mail
+    watch: gmail.inbox
+    filter: "from:boss@company.com"
+    action: agent.run("Phân loại + draft reply")
+    
+  - name: standup_reminder
+    cron: "55 9 * * 1-5"        # 9:55 sáng thứ 2-6
+    action: agent.run("Chuẩn bị standup update từ git log hôm qua")
+```
+
+## Example 8: Mapping về Underthesea hiện tại
+
+```python
+# Hiện tại underthesea.agent — sync, single-shot:
+from underthesea.agent import Agent, default_tools
+a = Agent("assistant", tools=default_tools)
+a("Tóm tắt inbox")   # ← user phải gọi tay
+
+# Hình dung sau khi thêm Personal AI OS layer:
+from underthesea.agent.os import PersonalAIOS
+
+os = PersonalAIOS(agent=a, memory_dir="./memory")
+os.add_channel("zalo", credentials=...)
+os.add_heartbeat("0 7 * * *", "Tóm tắt inbox")
+os.add_node("phone", capabilities=["camera"])
+os.serve()   # ← daemon chạy 24/7
+
+# User gửi tin Zalo → Gateway nhận → Orchestrator route → Agent xử lý
+# 7AM mỗi sáng → Heartbeat trigger → push notification
+```
+
+Đây là **gap** giữa SDK hiện tại và Personal AI OS — không cần xây hết, có thể chỉ chọn 1-2 pattern.

--- a/docs/research/personal-ai-os/04-roadmap.md
+++ b/docs/research/personal-ai-os/04-roadmap.md
@@ -1,0 +1,96 @@
+# Personal AI OS — Roadmap (for Underthesea)
+
+> Last updated: 2026-05-17
+
+Underthesea **không** đặt mục tiêu trở thành Personal AI OS đầy đủ (đó là phạm vi của OpenClaw). Roadmap này chọn lọc **pattern phù hợp với Vietnamese NLP context** và lộ trình thử nghiệm.
+
+## Phase 0 — Status hiện tại (đã có)
+
+- ✅ `Agent` class với tool loop (OpenAI function-calling)
+- ✅ Multi-provider LLM (`OpenAI`, `Azure`, `Anthropic`, `Gemini`)
+- ✅ `SessionManager` + `ContextManager` — context reset + handoff (Anthropic pattern)
+- ✅ `WikiAgent` — markdown-as-memory cho personal KB (giống Karpathy thesis)
+- ✅ Tracing (`LocalTracer`, `LangfuseTracer`) + auto-trace
+
+## Phase 1 — Reliability patterns (1-2 tháng)
+
+Mượn từ OpenClaw mà KHÔNG cần daemon:
+
+- [ ] **Lane Queue** cho `default_tools` có side-effect (`write_file`, `shell`, `python`)
+  - Implement: simple `asyncio.Queue` per lane name
+  - Test: 2 tool call `write_file` đồng thời → serialize
+- [ ] **Semantic Snapshot** cho `fetch_url_tool`
+  - Implement: dùng `playwright` accessibility tree thay raw HTML
+  - Fallback: HTML nếu không có browser
+  - Test: token count giảm ≥ 5x trên top 10 site Việt Nam
+- [ ] **Tool dedup** trong cùng iteration
+  - Hash tool name + args, skip duplicate trong 1 turn
+
+**Deliverable**: `underthesea.agent.runtime` module với `LaneQueue` + `SnapshotTool`.
+
+## Phase 2 — Memory-first abstraction (2-3 tháng)
+
+- [ ] Tách `WikiAgent` thành `Memory` interface chung
+  - `MarkdownMemory(dir)` — current `WikiAgent` style
+  - `VectorMemory(dir)` — embed + retrieve qua FAISS/Chroma
+  - `HybridMemory` — markdown làm source-of-truth, vector làm index
+- [ ] Agent có thể attach memory: `Agent(name, memory=MarkdownMemory("./mem"))`
+- [ ] Auto-commit memory changes (git-backed, optional)
+
+**Deliverable**: `underthesea.agent.memory` module.
+
+## Phase 3 — Ambient triggers (3-4 tháng)
+
+- [ ] `Heartbeat` scheduler — cron-style trong Python process
+  - `Heartbeat.add("0 7 * * *", agent_callable)`
+  - Có thể standalone hoặc embed vào caller process
+- [ ] `Watcher` abstractions:
+  - `FileWatcher` (qua `watchdog`)
+  - `EmailWatcher` (IMAP/Gmail API)
+  - `WebhookReceiver` (FastAPI subapp)
+- [ ] Vietnamese-specific: thử nghiệm `ZaloWatcher` (Zalo Official Account API)
+
+**Deliverable**: `underthesea.agent.ambient` module.
+
+## Phase 4 — Multi-agent orchestrator (4-6 tháng)
+
+- [ ] `Orchestrator` route message tới agent phù hợp dựa trên intent
+- [ ] Built-in specialized agents cho NLP Việt Nam:
+  - `TokenizerAgent`, `NERAgent`, `SentimentAgent`, `SummaryAgent`
+  - `WikiAgent` (đã có)
+- [ ] Handoff giữa agent qua `Memory` chung
+
+**Deliverable**: `underthesea.agent.orchestrator` module + reference agents.
+
+## Phase 5 — Optional: Gateway daemon (nếu cộng đồng yêu cầu)
+
+Đây là phạm vi **lớn**, có thể spin-off thành package riêng (`underthesea-os`):
+
+- [ ] WebSocket gateway daemon
+- [ ] Device pairing + token
+- [ ] Node protocol (laptop ↔ phone capability advertise)
+- [ ] Channel integration: Zalo, Telegram, iMessage, Slack
+- [ ] CLI launcher: `underthesea-os start`
+
+**Quyết định Go/No-go**: cuối Phase 4, đánh giá nhu cầu thực tế.
+
+## Quyết định cần làm sớm
+
+1. **Scope ownership**: `underthesea.agent.*` có nên tách thành package riêng (`uts-agent`)?
+2. **Cloud vs local**: target user dev (local) hay end-user (cloud-hosted)?
+3. **Memory persistence**: file-based default? SQLite optional?
+4. **Vietnamese channel priority**: Zalo > Messenger > email — đúng không?
+
+## Non-goals
+
+- ❌ Không clone OpenClaw 1:1 — quá rộng so với core NLP mission
+- ❌ Không xây UI app (macOS/iOS/Android) — để cộng đồng làm
+- ❌ Không cạnh tranh Siri / Apple Intelligence ở consumer space
+- ❌ Không lock vào 1 LLM provider — giữ multi-provider
+
+## Success metrics (cuối 2026)
+
+- Phase 1-2 ship → ≥ 3 user thực tế dùng `WikiAgent` cho personal KB tiếng Việt
+- Phase 3 ship → ≥ 1 case study: ambient agent cho email Vietnamese triage
+- Repo `underthesea` thêm ≥ 500 ⭐ nhờ agent capability
+- Có ≥ 1 PR cộng đồng cho Zalo/Messenger watcher


### PR DESCRIPTION
## Summary
- Add 4-file research bundle under `docs/research/personal-ai-os/` (design, research, examples, roadmap)
- Explore patterns from OpenClaw (gateway, lane queue, semantic snapshot, ambient triggers, markdown memory) and how Underthesea agent could selectively adopt them
- Follows the same folder structure as `docs/research/agent-simulation/`

## Test plan
- [x] All 4 markdown files render correctly
- [x] No code changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)