### PR TITLE
docs(research): pivot personal-ai-os notes to global positioning

### DIFF
--- a/docs/research/personal-ai-os/01-design.md
+++ b/docs/research/personal-ai-os/01-design.md
@@ -1,6 +1,7 @@
 # Personal AI OS — Design Document
 
 > Last updated: 2026-05-17
+> Direction note (2026-05-17): Underthesea growth strategy pivot sang **global positioning**, không dùng Vietnamese identity làm marketing lever. Xem `04-roadmap.md` cho M1/M2/M3 plan đã duyệt.
 
 ## 1. Problem
 
@@ -113,6 +114,7 @@ Underthesea hiện ở **Layer 1 (SDK)** — nếu muốn lên Personal AI OS ph
 
 ## 6. Open questions
 
-1. Có nên tách `underthesea.agent` thành package độc lập để target Personal AI OS không?
-2. Vietnamese-specific channels nào quan trọng (Zalo, Lotus)?
-3. Self-hosted vs cloud trade-off cho user Việt Nam?
+1. Có nên tách `underthesea.agent` thành package độc lập (`uts-agent`) để target Personal AI OS / smallest-agent positioning không?
+2. Channel priority cho global audience: Telegram > Slack > Email > Discord — đúng thứ tự?
+3. Self-hosted vs managed (HF Space) trade-off cho onboarding lần đầu?
+4. ~~Vietnamese-specific channels (Zalo, Lotus)~~ — Deprioritized 2026-05-17 per roadmap pivot. Có thể revisit sau M3 nếu cộng đồng VN tự request.

--- a/docs/research/personal-ai-os/02-research.md
+++ b/docs/research/personal-ai-os/02-research.md
@@ -1,6 +1,7 @@
 # Personal AI OS — Research
 
 > Last updated: 2026-05-17
+> Direction note (2026-05-17): Section 4.5 (Vietnamese context) deprioritized per roadmap pivot sang global positioning. Giữ lại làm reference, không dùng làm marketing input.
 
 ## 1. Trend overview
 
@@ -105,10 +106,19 @@ Personal AI OS là sự hội tụ của 4 trend agentic AI nổi bật trong 20
 - Quá nhiều inbox watcher → noise
 - Cần rate limit + dedup pattern
 
-### 4.5 Vietnamese context
+### 4.5 Vietnamese context (DEPRIORITIZED 2026-05-17)
+> Giữ lại làm reference cho hướng đi phụ; **không** dùng làm input cho marketing/roadmap chính.
+
 - Channel chính: Zalo (API hạn chế), Facebook Messenger
 - Email tiếng Việt cần segmentation/normalization (đây là điểm Underthesea có thể mạnh)
 - Voice (TTS/STT) tiếng Việt vẫn yếu so với English
+
+### 4.6 Global channel priority (cho roadmap chính)
+- **Telegram** — Bot API đơn giản nhất, không cần OAuth phức tạp, dùng làm killer demo M2
+- **Slack** — developer audience rộng, Socket Mode dễ self-host
+- **Email (IMAP)** — universal, không cần platform credential
+- **Discord** — community-friendly, bot infra tốt
+- ~~Zalo/WeChat/LINE~~ — regional-specific, không trong scope global growth
 
 ## 5. References
 

--- a/docs/research/personal-ai-os/03-examples.md
+++ b/docs/research/personal-ai-os/03-examples.md
@@ -1,6 +1,7 @@
 # Personal AI OS — Examples
 
 > Last updated: 2026-05-17
+> Direction note (2026-05-17): Ví dụ vẫn dùng ngôn ngữ Việt (vì đây là internal research notes), nhưng channel mapping ở Example 8 đã cập nhật theo M2 plan (Telegram/Slack/Email thay vì Zalo).
 
 Các ví dụ minh hoạ cách Personal AI OS hoạt động khác với CLI agent / chatbot truyền thống.
 
@@ -143,13 +144,14 @@ a("Tóm tắt inbox")   # ← user phải gọi tay
 from underthesea.agent.os import PersonalAIOS
 
 os = PersonalAIOS(agent=a, memory_dir="./memory")
-os.add_channel("zalo", credentials=...)
+os.add_channel("telegram", token=...)        # M2 default
+os.add_channel("slack", bot_token=...)       # M2 optional
+os.add_channel("email", imap_host=...)       # M2 optional
 os.add_heartbeat("0 7 * * *", "Tóm tắt inbox")
-os.add_node("phone", capabilities=["camera"])
 os.serve()   # ← daemon chạy 24/7
 
-# User gửi tin Zalo → Gateway nhận → Orchestrator route → Agent xử lý
-# 7AM mỗi sáng → Heartbeat trigger → push notification
+# User gửi tin Telegram → Gateway nhận → Agent xử lý → reply
+# 7AM mỗi sáng → Heartbeat trigger → push morning brief
 ```
 
 Đây là **gap** giữa SDK hiện tại và Personal AI OS — không cần xây hết, có thể chỉ chọn 1-2 pattern.

--- a/docs/research/personal-ai-os/04-roadmap.md
+++ b/docs/research/personal-ai-os/04-roadmap.md
@@ -1,96 +1,139 @@
 # Personal AI OS — Roadmap (for Underthesea)
 
 > Last updated: 2026-05-17
+> Aligned với plan `~/.claude/plans/xu-t-roadmap-cho-mighty-candy.md` đã duyệt 2026-05-17.
 
-Underthesea **không** đặt mục tiêu trở thành Personal AI OS đầy đủ (đó là phạm vi của OpenClaw). Roadmap này chọn lọc **pattern phù hợp với Vietnamese NLP context** và lộ trình thử nghiệm.
+Underthesea **không** đặt mục tiêu trở thành Personal AI OS đầy đủ (đó là phạm vi của OpenClaw). Roadmap này chọn lọc **pattern phù hợp** và lộ trình ship + hype theo 3 milestone trong 6 tháng. Positioning thuần **global** — không dùng Vietnamese identity làm marketing lever.
 
-## Phase 0 — Status hiện tại (đã có)
+## Phase 0 — Status hiện tại (đã có ở v9.5.0)
 
 - ✅ `Agent` class với tool loop (OpenAI function-calling)
 - ✅ Multi-provider LLM (`OpenAI`, `Azure`, `Anthropic`, `Gemini`)
 - ✅ `SessionManager` + `ContextManager` — context reset + handoff (Anthropic pattern)
 - ✅ `WikiAgent` — markdown-as-memory cho personal KB (giống Karpathy thesis)
 - ✅ Tracing (`LocalTracer`, `LangfuseTracer`) + auto-trace
+- ✅ A2A-compatible agent server (`underthesea.agent.server`) — bundled chat UI, per-session isolation, tool streaming
+- ✅ Zero external deps cho core (`urllib` + `json` only)
 
-## Phase 1 — Reliability patterns (1-2 tháng)
+## Milestone 1 — "Smallest Agent Framework + Free Assistant TUI" (T1-T2, ~2.5 tháng)
 
-Mượn từ OpenClaw mà KHÔNG cần daemon:
+Mượn pattern từ OpenClaw mà KHÔNG cần daemon. Mục tiêu: positioning + first hype moment (Show HN).
 
+### Runtime patterns
 - [ ] **Lane Queue** cho `default_tools` có side-effect (`write_file`, `shell`, `python`)
   - Implement: simple `asyncio.Queue` per lane name
+  - Decorator: `@lane("messaging")`
   - Test: 2 tool call `write_file` đồng thời → serialize
 - [ ] **Semantic Snapshot** cho `fetch_url_tool`
-  - Implement: dùng `playwright` accessibility tree thay raw HTML
+  - Dùng `playwright` accessibility tree thay raw HTML
   - Fallback: HTML nếu không có browser
-  - Test: token count giảm ≥ 5x trên top 10 site Việt Nam
+  - Test: token count giảm ≥ 5x trên top 10 site phổ biến (HN, GitHub, Wikipedia, Reddit, SO…)
 - [ ] **Tool dedup** trong cùng iteration
   - Hash tool name + args, skip duplicate trong 1 turn
 
-**Deliverable**: `underthesea.agent.runtime` module với `LaneQueue` + `SnapshotTool`.
+### Underthesea Assistant TUI (NEW — OpenClaw-style claude-cli bridge)
+- [ ] **CLI subcommand**: `underthesea assistant` — launch TUI app
+- [ ] **TUI** với `textual` — chat panel + input box + status bar (streaming token-by-token)
+- [ ] **ClaudeBridge**: spawn `claude --print --output-format=stream-json` subprocess, parse stream
+  - Dùng `claude login` subscription của user → **free** (không tốn API token)
+  - Đây là USP cực mạnh: "Free Personal AI Assistant on your Claude Pro/Max subscription"
+- [ ] **Session/history**: persist conversation vào markdown file (precursor của MarkdownMemory M2)
+- [ ] Optional extra `[assistant]`: `textual`, `rich` (không cần `claude-agent-sdk` vì dùng subprocess)
 
-## Phase 2 — Memory-first abstraction (2-3 tháng)
+### Marketing infra
+- [ ] **README rewrite** + CONTRIBUTING.md + issue/PR templates + Discord setup
 
+**Deliverable**: `underthesea.agent.runtime` (LaneQueue + SnapshotTool) + `underthesea.agent.assistant` (TUI + ClaudeBridge).
+
+**Hype**: Show HN dual angle: *"Smallest agent framework + free TUI assistant using your Claude subscription"* — combo này độc nhất, đủ wow cho HN front page. dev.to blog, Twitter thread, 5 AI newsletter outreach. Demo GIF 15s của TUI là asset chính.
+
+## Milestone 2 — "Personal AI OS in Pure Python" (T3-T4, ~2 tháng)
+
+Memory-first + ambient triggers + killer demo app.
+
+### Memory layer
 - [ ] Tách `WikiAgent` thành `Memory` interface chung
-  - `MarkdownMemory(dir)` — current `WikiAgent` style
-  - `VectorMemory(dir)` — embed + retrieve qua FAISS/Chroma
+  - `MarkdownMemory(dir)` — current `WikiAgent` style (default)
+  - `VectorMemory(dir)` — embed + retrieve qua FAISS/Chroma (optional)
   - `HybridMemory` — markdown làm source-of-truth, vector làm index
 - [ ] Agent có thể attach memory: `Agent(name, memory=MarkdownMemory("./mem"))`
 - [ ] Auto-commit memory changes (git-backed, optional)
 
-**Deliverable**: `underthesea.agent.memory` module.
-
-## Phase 3 — Ambient triggers (3-4 tháng)
-
+### Ambient triggers
 - [ ] `Heartbeat` scheduler — cron-style trong Python process
   - `Heartbeat.add("0 7 * * *", agent_callable)`
-  - Có thể standalone hoặc embed vào caller process
 - [ ] `Watcher` abstractions:
-  - `FileWatcher` (qua `watchdog`)
-  - `EmailWatcher` (IMAP/Gmail API)
-  - `WebhookReceiver` (FastAPI subapp)
-- [ ] Vietnamese-specific: thử nghiệm `ZaloWatcher` (Zalo Official Account API)
+  - `TelegramWatcher` — Bot API (default, dễ onboard nhất)
+  - `SlackWatcher` — Socket Mode / Events API
+  - `EmailWatcher` — IMAP polling
+  - `FileWatcher` (qua `watchdog`) — optional
+  - `WebhookReceiver` (FastAPI subapp) — optional
+- [ ] ~~`ZaloWatcher`~~ — Deprioritized 2026-05-17. Channel global hơn (Telegram/Slack) phủ rộng audience hơn nhiều lần.
 
-**Deliverable**: `underthesea.agent.ambient` module.
+### Killer demo
+- [ ] `examples/personal-ai-os/` — Telegram bot tự triage tin nhắn + reply + nhớ context qua MarkdownMemory + morning brief 7AM
+- [ ] One-command setup: `python -m examples.personal-ai-os start`
+- [ ] GIF demo + README riêng
 
-## Phase 4 — Multi-agent orchestrator (4-6 tháng)
+**Deliverable**: `underthesea.agent.memory` + `underthesea.agent.ambient` modules + working demo app.
 
-- [ ] `Orchestrator` route message tới agent phù hợp dựa trên intent
-- [ ] Built-in specialized agents cho NLP Việt Nam:
-  - `TokenizerAgent`, `NERAgent`, `SentimentAgent`, `SummaryAgent`
-  - `WikiAgent` (đã có)
-- [ ] Handoff giữa agent qua `Memory` chung
+**Hype**: dev.to/Substack blog "Self-hosted Jarvis in 50 LOC", YouTube live coding, PyCon US/EuroPython CFP, podcast pitch (Latent Space, Practical AI), Reddit cross-post (r/Python, r/selfhosted, r/LocalLLaMA).
 
-**Deliverable**: `underthesea.agent.orchestrator` module + reference agents.
+## Milestone 3 — "Growth Amplification" (T5-T6, ~2 tháng)
 
-## Phase 5 — Optional: Gateway daemon (nếu cộng đồng yêu cầu)
+Không build feature mới. Polish + deploy + launch + retrospective.
+
+- [ ] **HuggingFace Space** deploy demo M2 — public link, anybody can try
+- [ ] **Benchmark suite** `benchmarks/agent_comparison/` — Underthesea vs LangGraph/CrewAI/AutoGen: latency, token cost, cold-start, LOC, deps count. Reproducible Colab notebook.
+- [ ] **Bug bash** — fix mọi issue user đã tạo từ M1+M2, target 0 critical bug trước Product Hunt
+- [ ] **Telegram bot template** (cookiecutter) — `pip install underthesea-telegram-bot`
+- [ ] **Product Hunt launch** — chuẩn bị visual + 5-day pre-launch warmup
+- [ ] **Benchmark blog** đăng HN + r/MachineLearning + Lobsters
+- [ ] **Online hackathon** "Build with Underthesea" — Devpost / MLH cross-promote
+- [ ] **Retrospective blog** — số liệu thật sau 6 tháng (stars, downloads, sponsors)
+- [ ] **Discord events** — weekly office hour, AMA, showcase
+
+**Deliverable**: HF Space public, benchmark numbers công khai, ≥ 3 viral content moment.
+
+## Phase 5 — Optional: Gateway daemon (chỉ nếu cộng đồng yêu cầu)
 
 Đây là phạm vi **lớn**, có thể spin-off thành package riêng (`underthesea-os`):
 
 - [ ] WebSocket gateway daemon
 - [ ] Device pairing + token
 - [ ] Node protocol (laptop ↔ phone capability advertise)
-- [ ] Channel integration: Zalo, Telegram, iMessage, Slack
+- [ ] Channel integration mở rộng: WhatsApp, iMessage, Discord webhook
 - [ ] CLI launcher: `underthesea-os start`
 
-**Quyết định Go/No-go**: cuối Phase 4, đánh giá nhu cầu thực tế.
+**Quyết định Go/No-go**: cuối M3, đánh giá nhu cầu thực tế từ Discord/issue tracker.
+
+## Scope cut (so với roadmap cũ)
+
+- ❌ **Multi-agent orchestrator + specialized NLP agents** — cut khỏi 6-month plan. Single Agent + Lane Queue đã đủ cho "smallest agent framework" narrative. Multi-agent là enterprise pattern, không phải hype-friendly.
+- ❌ **Vietnamese-specific channels (Zalo)** — cut. Telegram/Slack/Email phủ audience global rộng hơn.
+- ❌ **Vietnamese-specific case studies** — cut khỏi success metrics. User VN cũ không phải audience growth target.
 
 ## Quyết định cần làm sớm
 
-1. **Scope ownership**: `underthesea.agent.*` có nên tách thành package riêng (`uts-agent`)?
-2. **Cloud vs local**: target user dev (local) hay end-user (cloud-hosted)?
-3. **Memory persistence**: file-based default? SQLite optional?
-4. **Vietnamese channel priority**: Zalo > Messenger > email — đúng không?
+1. **Scope ownership**: tách `underthesea.agent` thành package riêng (`uts-agent`)? **Recommend tách**, vì brand "Underthesea" gắn liền NLP Việt Nam có thể conflict với global positioning mới.
+2. **Cloud vs local**: target dev (local) hay end-user (managed)? **Recommend local-first**, managed = HF Space demo cho try-before-install.
+3. **Memory persistence**: file-based default? SQLite optional? **Recommend MarkdownMemory default**, git-backed auto-commit là optional.
+4. **README rebrand**: đổi tagline + visual identity, hay giữ name `underthesea`? **Recommend giữ name, đổi tagline** (đổi tên = mất 9 năm SEO/credibility).
 
 ## Non-goals
 
-- ❌ Không clone OpenClaw 1:1 — quá rộng so với core NLP mission
+- ❌ Không clone OpenClaw 1:1 — quá rộng so với core mission
 - ❌ Không xây UI app (macOS/iOS/Android) — để cộng đồng làm
 - ❌ Không cạnh tranh Siri / Apple Intelligence ở consumer space
-- ❌ Không lock vào 1 LLM provider — giữ multi-provider
+- ❌ Không lock vào 1 LLM provider — giữ multi-provider làm USP
+- ❌ Không dùng Vietnamese identity làm marketing lever
+- ❌ Không train model mới — reuse pipeline đã có
 
-## Success metrics (cuối 2026)
+## Success metrics (cuối tháng 11/2026)
 
-- Phase 1-2 ship → ≥ 3 user thực tế dùng `WikiAgent` cho personal KB tiếng Việt
-- Phase 3 ship → ≥ 1 case study: ambient agent cho email Vietnamese triage
-- Repo `underthesea` thêm ≥ 500 ⭐ nhờ agent capability
-- Có ≥ 1 PR cộng đồng cho Zalo/Messenger watcher
+- ≥ 5,000 GitHub ⭐ growth (baseline tháng 5/2026)
+- ≥ 100 GitHub sponsors (3.3x từ 30 hiện tại)
+- ≥ 3 viral content moment (Show HN front page, Twitter ≥ 1k like, Reddit top-10)
+- ≥ 1 killer demo app deployed với active user thật
+- Discord ≥ 500 thành viên
+- ≥ 1 case study người dùng thật post lên Twitter/blog của họ


### PR DESCRIPTION
## Summary

Align the four `docs/research/personal-ai-os/*` notes with the May 2026 growth roadmap decision to target a global audience instead of Vietnamese-specific channels.

- **01-design**: add direction note; replace Zalo/Lotus open question with global channel priority + package split question.
- **02-research**: deprioritize the 4.5 Vietnamese context section; add 4.6 Global channel priority (Telegram / Slack / Email / Discord).
- **03-examples**: swap the `zalo` channel for `telegram` / `slack` / `email` in the PersonalAIOS sketch; drop the multi-node hint that is no longer in scope.
- **04-roadmap**: rewrite into a 3-milestone plan (M1 Smallest Agent Framework, M2 Personal AI OS, M3 Growth Amplification), drop the multi-agent orchestrator phase, replace ZaloWatcher with Slack/Telegram/Email watchers, update success metrics.

## Test plan

- [x] All four files render correctly as markdown
- [x] No broken cross-references
- [x] Direction notes clearly mark which content is deprioritized vs current