### PR TITLE
feat(agent): add assistant TUI bridging local claude CLI

### DIFF
--- a/docs/research/personal-ai-os/04-roadmap.md
+++ b/docs/research/personal-ai-os/04-roadmap.md
@@ -32,7 +32,7 @@ Mượn pattern từ OpenClaw mà KHÔNG cần daemon. Mục tiêu: positioning 
   - Hash tool name + args, skip duplicate trong 1 turn
 
 ### Underthesea Assistant TUI (NEW — OpenClaw-style claude-cli bridge)
-- [ ] **CLI subcommand**: `underthesea assistant` — launch TUI app
+- [ ] **CLI subcommand**: `underthesea chat` — launch TUI app
 - [ ] **TUI** với `textual` — chat panel + input box + status bar (streaming token-by-token)
 - [ ] **ClaudeBridge**: spawn `claude --print --output-format=stream-json` subprocess, parse stream
   - Dùng `claude login` subscription của user → **free** (không tốn API token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ trace = [
 test = [
     "nose==1.3.7"
 ]
+test-tui = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "pytest-textual-snapshot>=1.0",
+]
 dev = [
     "ruff>=0.9.0",
     "tox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ agent-server = [
     "starlette>=0.49.1,<1",
     "httpx>=0.27,<1",
 ]
+assistant = [
+    "textual>=0.50",
+    "rich>=13.0",
+]
 trace = [
     "langfuse>=2.0.0"
 ]

--- a/tests/agent/assistant/__snapshots__/test_tui_snapshot/test_after_user_turn.svg
+++ b/tests/agent/assistant/__snapshots__/test_tui_snapshot/test_after_user_turn.svg
@@ -1,0 +1,136 @@
+<svg class="rich-terminal" viewBox="0 0 994 538.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #e6e6e6 }
+.terminal-r3 { fill: #8b949e }
+.terminal-r4 { fill: #121212 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="487.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="536" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">AssistantApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#0d1117" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="24.4" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="122" y="50.3" width="854" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="24.4" y="123.5" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="939.4" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="12.2" y="440.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="829.6" y="440.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#20242b" x="0" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="24.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#20242b" x="36.6" y="465.1" width="939.4" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r2" x="24.4" y="68.8" textLength="97.6" clip-path="url(#terminal-line-2)">xin&#160;chào</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r2" x="24.4" y="142" textLength="902.8" clip-path="url(#terminal-line-5)">Chào&#160;bạn!&#160;Mình&#160;là&#160;Uts&#160;🪸&#160;—&#160;đang&#160;chạy&#160;trên&#160;Claude&#160;qua&#160;Underthesea&#160;Assistant.</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="12.2" y="459.2" textLength="817.4" clip-path="url(#terminal-line-18)">idle&#160;|&#160;underthesea-agent/after-turn&#160;|&#160;haiku&#160;|&#160;fake1234…&#160;|&#160;1.5k/200k</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/agent/assistant/__snapshots__/test_tui_snapshot/test_empty_app.svg
+++ b/tests/agent/assistant/__snapshots__/test_tui_snapshot/test_empty_app.svg
@@ -1,0 +1,135 @@
+<svg class="rich-terminal" viewBox="0 0 994 538.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #8b949e }
+.terminal-r3 { fill: #121212 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="487.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="536" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">AssistantApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#0d1117" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="50.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="123.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="12.2" y="440.7" width="695.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="707.6" y="440.7" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#20242b" x="0" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="24.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#20242b" x="36.6" y="465.1" width="939.4" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r2" x="12.2" y="459.2" textLength="695.4" clip-path="url(#terminal-line-18)">idle&#160;|&#160;underthesea-agent/snapshot&#160;|&#160;haiku&#160;|&#160;—&#160;|&#160;0.0k/200k</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/agent/assistant/__snapshots__/test_tui_snapshot/test_resumed_session_renders_history.svg
+++ b/tests/agent/assistant/__snapshots__/test_tui_snapshot/test_resumed_session_renders_history.svg
@@ -1,0 +1,136 @@
+<svg class="rich-terminal" viewBox="0 0 994 538.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #e6e6e6 }
+.terminal-r3 { fill: #8b949e }
+.terminal-r4 { fill: #121212 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="487.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="536" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">AssistantApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#0d1117" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="0" y="25.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="0" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="24.4" y="50.3" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="305" y="50.3" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#2a3447" x="0" y="74.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="99.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="24.4" y="123.5" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="683.2" y="123.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="147.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="172.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="196.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="221.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="245.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="269.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="12.2" y="440.7" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0d1117" x="793" y="440.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#20242b" x="0" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="24.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#20242b" x="36.6" y="465.1" width="939.4" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r2" x="24.4" y="68.8" textLength="280.6" clip-path="url(#terminal-line-2)">Trước&#160;đó&#160;bạn&#160;đã&#160;hỏi&#160;gì?</text><text class="terminal-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r2" x="24.4" y="142" textLength="658.8" clip-path="url(#terminal-line-5)">Đây&#160;là&#160;câu&#160;trả&#160;lời&#160;cũ&#160;—&#160;render&#160;lại&#160;khi&#160;resume&#160;session.</text><text class="terminal-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="12.2" y="459.2" textLength="780.8" clip-path="url(#terminal-line-18)">idle&#160;|&#160;underthesea-agent/resumed&#160;|&#160;haiku&#160;|&#160;abc12345…&#160;|&#160;0.0k/200k</text><text class="terminal-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/agent/assistant/test_bridge.py
+++ b/tests/agent/assistant/test_bridge.py
@@ -1,0 +1,225 @@
+"""Tests for ClaudeBridge — subprocess wrapper around `claude` CLI."""
+
+import asyncio
+from unittest import TestCase
+from unittest.mock import patch
+
+from underthesea.agent.assistant.bridge import (
+    BridgeError,
+    ClaudeBridge,
+    ClaudeNotFoundError,
+    StreamEvent,
+)
+
+
+def _async(coro):
+    return asyncio.run(coro)
+
+
+class FakeStream:
+    """Async iterator over predetermined byte lines."""
+
+    def __init__(self, lines: list[bytes]):
+        self._lines = list(lines)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0)
+
+    async def read(self) -> bytes:
+        return b""
+
+
+class TestStreamEvent(TestCase):
+    def test_text_chunk_extracts_text(self):
+        ev = StreamEvent(
+            type="assistant",
+            raw={"message": {"content": [{"type": "text", "text": "Hello"}]}},
+        )
+        self.assertTrue(ev.is_text_chunk)
+        self.assertEqual(ev.text, "Hello")
+
+    def test_concatenates_multiple_text_blocks(self):
+        ev = StreamEvent(
+            type="assistant",
+            raw={
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Hello "},
+                        {"type": "text", "text": "world"},
+                    ]
+                }
+            },
+        )
+        self.assertEqual(ev.text, "Hello world")
+
+    def test_thinking_block_is_not_text_chunk(self):
+        ev = StreamEvent(
+            type="assistant",
+            raw={"message": {"content": [{"type": "thinking", "thinking": "..."}]}},
+        )
+        self.assertFalse(ev.is_text_chunk)
+        self.assertEqual(ev.text, "")
+
+    def test_tool_use_extracted(self):
+        ev = StreamEvent(
+            type="assistant",
+            raw={
+                "message": {
+                    "content": [{"type": "tool_use", "name": "Bash", "input": {"cmd": "ls"}}]
+                }
+            },
+        )
+        self.assertEqual(ev.tool_use["name"], "Bash")
+
+    def test_result_event_has_cost(self):
+        ev = StreamEvent(type="result", raw={"total_cost_usd": 0.0123})
+        self.assertTrue(ev.is_done)
+        self.assertAlmostEqual(ev.cost_usd, 0.0123)
+
+
+class TestClaudeBridgeCheck(TestCase):
+    def test_missing_binary_raises(self):
+        bridge = ClaudeBridge(binary="definitely-not-claude-xyz-1234")
+        with self.assertRaises(ClaudeNotFoundError) as ctx:
+            bridge.check()
+        self.assertIn("not found", str(ctx.exception))
+        self.assertIn("claude login", str(ctx.exception))
+
+    @patch("underthesea.agent.assistant.bridge.shutil.which", return_value="/usr/local/bin/claude")
+    def test_present_binary_returns_path(self, _):
+        bridge = ClaudeBridge()
+        self.assertEqual(bridge.check(), "/usr/local/bin/claude")
+
+
+class TestBuildArgs(TestCase):
+    @patch("underthesea.agent.assistant.bridge.shutil.which", return_value="/x/claude")
+    def test_default_args(self, _):
+        bridge = ClaudeBridge()
+        args = bridge._build_args("hi")
+        self.assertEqual(args[0], "claude")
+        self.assertIn("--print", args)
+        self.assertIn("--output-format", args)
+        self.assertIn("stream-json", args)
+        self.assertEqual(args[-1], "hi")
+        self.assertNotIn("--model", args)
+        self.assertNotIn("--resume", args)
+
+    def test_model_added_when_set(self):
+        bridge = ClaudeBridge(model="haiku")
+        args = bridge._build_args("hi")
+        i = args.index("--model")
+        self.assertEqual(args[i + 1], "haiku")
+
+    def test_resume_added_when_session_id(self):
+        bridge = ClaudeBridge()
+        bridge.session_id = "abc-123"
+        args = bridge._build_args("hi")
+        i = args.index("--resume")
+        self.assertEqual(args[i + 1], "abc-123")
+
+
+class TestParseStream(TestCase):
+    def test_parses_jsonl_and_skips_empty(self):
+        lines = [
+            b'{"type":"system","session_id":"abc"}\n',
+            b"\n",
+            b'{"type":"assistant","message":{"content":[]},"session_id":"abc"}\n',
+            b'not-json\n',
+            b'{"type":"result","total_cost_usd":0.01,"session_id":"abc"}\n',
+        ]
+
+        async def collect():
+            events = []
+            async for ev in ClaudeBridge._parse_stream(FakeStream(lines)):
+                events.append(ev)
+            return events
+
+        events = _async(collect())
+        types = [e.type for e in events]
+        self.assertEqual(types, ["system", "assistant", "result"])
+        self.assertEqual(events[0].session_id, "abc")
+        self.assertTrue(events[-1].is_done)
+
+
+class TestSendSessionTracking(TestCase):
+    def test_send_updates_session_id_from_first_event(self):
+        """Mock the subprocess so we can verify session_id pickup without a real claude binary."""
+
+        class FakeProc:
+            def __init__(self):
+                self.stdout = FakeStream(
+                    [
+                        b'{"type":"system","session_id":"xyz-456","subtype":"init"}\n',
+                        b'{"type":"result","session_id":"xyz-456","total_cost_usd":0.0}\n',
+                    ]
+                )
+                self.stderr = FakeStream([])
+                self.returncode = 0
+
+            async def wait(self):
+                return 0
+
+        async def fake_exec(*args, **kwargs):
+            return FakeProc()
+
+        bridge = ClaudeBridge()
+
+        async def go():
+            collected = []
+            with patch("underthesea.agent.assistant.bridge.shutil.which", return_value="/x/claude"):
+                with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+                    async for ev in bridge.send("hi"):
+                        collected.append(ev)
+            return collected
+
+        events = _async(go())
+        self.assertEqual(bridge.session_id, "xyz-456")
+        self.assertEqual(len(events), 2)
+
+    def test_nonzero_exit_raises(self):
+        class FakeProcFail:
+            def __init__(self):
+                self.stdout = FakeStream([])
+                self.stderr = FakeStream([b"boom\n"])
+
+                async def _wait():
+                    return 2
+
+                self.wait = _wait
+                self.returncode = 2
+
+            async def stderr_read(self):
+                return b"boom"
+
+        class StderrFail:
+            async def read(self):
+                return b"boom"
+
+        class FakeProc2:
+            def __init__(self):
+                self.stdout = FakeStream([])
+                self.stderr = StderrFail()
+                self.returncode = 2
+
+            async def wait(self):
+                return 2
+
+        async def fake_exec(*args, **kwargs):
+            return FakeProc2()
+
+        bridge = ClaudeBridge()
+
+        async def go():
+            with patch("underthesea.agent.assistant.bridge.shutil.which", return_value="/x/claude"):
+                with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+                    async for _ in bridge.send("hi"):
+                        pass
+
+        with self.assertRaises(BridgeError) as ctx:
+            _async(go())
+        self.assertIn("boom", str(ctx.exception))

--- a/tests/agent/assistant/test_session.py
+++ b/tests/agent/assistant/test_session.py
@@ -1,0 +1,73 @@
+"""Tests for Session — markdown-backed conversation log."""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from unittest import TestCase
+
+from underthesea.agent.assistant.session import Session, Turn
+
+
+class TestSession(TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+
+    def test_open_creates_empty_session_when_missing(self):
+        s = Session.open("new-chat", self.tmpdir)
+        self.assertEqual(s.name, "new-chat")
+        self.assertEqual(s.turns, [])
+        self.assertIsNone(s.claude_session_id)
+
+    def test_append_and_save_persists_turns(self):
+        s = Session.open("chat", self.tmpdir)
+        s.append("user", "Hello")
+        s.append("assistant", "Hi there")
+        s.claude_session_id = "abc-123"
+        s.model = "sonnet"
+        s.save()
+
+        content = (self.tmpdir / "chat.md").read_text()
+        self.assertIn("# session: chat", content)
+        self.assertIn("> claude_session_id: abc-123", content)
+        self.assertIn("> model: sonnet", content)
+        self.assertIn("## user", content)
+        self.assertIn("Hello", content)
+        self.assertIn("## assistant", content)
+        self.assertIn("Hi there", content)
+
+    def test_save_then_reopen_roundtrips(self):
+        s1 = Session.open("trip", self.tmpdir)
+        s1.append("user", "first")
+        s1.append("assistant", "second")
+        s1.claude_session_id = "uuid-xyz"
+        s1.model = "haiku"
+        s1.save()
+
+        s2 = Session.open("trip", self.tmpdir)
+        self.assertEqual(s2.claude_session_id, "uuid-xyz")
+        self.assertEqual(s2.model, "haiku")
+        self.assertEqual(len(s2.turns), 2)
+        self.assertEqual(s2.turns[0].role, "user")
+        self.assertEqual(s2.turns[0].content, "first")
+        self.assertEqual(s2.turns[1].role, "assistant")
+        self.assertEqual(s2.turns[1].content, "second")
+
+    def test_multiline_content_preserved(self):
+        s1 = Session.open("ml", self.tmpdir)
+        body = "line one\nline two\nline three"
+        s1.append("assistant", body)
+        s1.save()
+
+        s2 = Session.open("ml", self.tmpdir)
+        self.assertEqual(s2.turns[0].content, body)
+
+    def test_atomic_save_does_not_leave_tmp(self):
+        s = Session.open("atomic", self.tmpdir)
+        s.append("user", "x")
+        s.save()
+        files = sorted(p.name for p in self.tmpdir.iterdir())
+        self.assertEqual(files, ["atomic.md"])
+
+    def test_turn_default_ts_is_set(self):
+        t = Turn(role="user", content="hi")
+        self.assertIsInstance(t.ts, datetime)

--- a/tests/agent/assistant/test_tui_snapshot.py
+++ b/tests/agent/assistant/test_tui_snapshot.py
@@ -1,0 +1,141 @@
+"""Snapshot tests for the assistant TUI via pytest-textual-snapshot.
+
+Run:
+    pip install -e '.[assistant]' '.[test-tui]'
+    pytest tests/agent/assistant/test_tui_snapshot.py
+
+First run generates baseline SVGs under
+``tests/agent/assistant/__snapshots__/``. Subsequent runs diff against
+the baseline. Update intentional UI changes with ``pytest --snapshot-update``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from underthesea.agent.assistant.bridge import StreamEvent
+from underthesea.agent.assistant.session import Session
+from underthesea.agent.assistant.tui import build_app
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeBridge:
+    """ClaudeBridge stand-in that yields canned StreamEvents.
+
+    Mirrors the public attributes that the TUI reads (cwd, model,
+    session_id) and exposes an ``async def send(prompt)`` async generator.
+    """
+
+    def __init__(
+        self,
+        *,
+        events: list[StreamEvent] | None = None,
+        cwd: str = "/workspace/underthesea-agent",
+        model: str = "haiku",
+    ) -> None:
+        self.cwd = cwd
+        self.model = model
+        self.session_id: str | None = None
+        self._events = list(events or [])
+
+    def check(self) -> str:
+        return "/fake/claude"
+
+    async def send(self, prompt: str):
+        for ev in self._events:
+            if ev.session_id and not self.session_id:
+                self.session_id = ev.session_id
+            yield ev
+
+
+def _session(tmp_path: Path, name: str = "snapshot") -> Session:
+    return Session(name=name, path=tmp_path / f"{name}.md")
+
+
+# Canonical "one good turn" event sequence for the streaming snapshot.
+_GOOD_TURN = [
+    StreamEvent(
+        type="system",
+        raw={"subtype": "init", "session_id": "fake1234-5678-9abc-def0-000000000000"},
+        session_id="fake1234-5678-9abc-def0-000000000000",
+    ),
+    StreamEvent(
+        type="assistant",
+        raw={
+            "message": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Chào bạn! Mình là Uts 🪸 — đang chạy trên Claude qua Underthesea Assistant.",
+                    }
+                ]
+            }
+        },
+        session_id="fake1234-5678-9abc-def0-000000000000",
+    ),
+    StreamEvent(
+        type="result",
+        raw={
+            "total_cost_usd": 0.0123,
+            "usage": {
+                "input_tokens": 1500,
+                "output_tokens": 25,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            },
+        },
+        session_id="fake1234-5678-9abc-def0-000000000000",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_app(snap_compare, tmp_path):
+    """Baseline: fresh session, no turns yet."""
+    session = _session(tmp_path)
+    bridge = FakeBridge()
+    app = build_app(session, bridge)
+    assert snap_compare(app, terminal_size=(80, 20))
+
+
+def test_resumed_session_renders_history(snap_compare, tmp_path):
+    """A session loaded from disk should re-render its prior turns."""
+    session = _session(tmp_path, name="resumed")
+    session.append("user", "Trước đó bạn đã hỏi gì?")
+    session.append(
+        "assistant",
+        "Đây là câu trả lời cũ — render lại khi resume session.",
+    )
+    session.claude_session_id = "abc12345-6789-0000-1111-222222222222"
+
+    bridge = FakeBridge()
+    bridge.session_id = session.claude_session_id
+
+    app = build_app(session, bridge)
+    assert snap_compare(app, terminal_size=(80, 20))
+
+
+def test_after_user_turn(snap_compare, tmp_path):
+    """Drive a full turn: type, enter, stream done. Captures user bar +
+    assistant reply + status bar with token count + cost cleared."""
+    session = _session(tmp_path, name="after-turn")
+    bridge = FakeBridge(events=_GOOD_TURN)
+    app = build_app(session, bridge)
+
+    async def drive(pilot):
+        await pilot.press(*"xin chào")
+        await pilot.press("enter")
+        # Pump the event loop until the bridge.send generator is exhausted.
+        await pilot.pause()
+        await pilot.pause()
+
+    assert snap_compare(app, run_before=drive, terminal_size=(80, 20))

--- a/underthesea/agent/assistant/__init__.py
+++ b/underthesea/agent/assistant/__init__.py
@@ -1,0 +1,27 @@
+"""Underthesea Assistant — TUI agent bridging to the local `claude` CLI.
+
+This module spawns Claude Code as a subprocess and uses the user's existing
+`claude login` subscription, so no API key is required and no token cost is
+incurred beyond what Claude Code itself uses.
+
+Public API:
+    ClaudeBridge: subprocess wrapper that streams events from `claude --print`.
+    Session: markdown-backed conversation log persisted under
+        ~/.underthesea/assistant/<name>.md.
+    run_tui: launch the Textual chat UI (requires the `[assistant]` extra).
+"""
+from underthesea.agent.assistant.bridge import (
+    BridgeError,
+    ClaudeBridge,
+    ClaudeNotFoundError,
+    StreamEvent,
+)
+from underthesea.agent.assistant.session import Session
+
+__all__ = [
+    "BridgeError",
+    "ClaudeBridge",
+    "ClaudeNotFoundError",
+    "Session",
+    "StreamEvent",
+]

--- a/underthesea/agent/assistant/__init__.py
+++ b/underthesea/agent/assistant/__init__.py
@@ -24,4 +24,17 @@ __all__ = [
     "ClaudeNotFoundError",
     "Session",
     "StreamEvent",
+    "build_app",
+    "run_tui",
 ]
+
+
+def __getattr__(name):
+    """Lazy re-export of TUI helpers so importing this module does not
+    require the optional ``textual`` dependency until those names are used.
+    """
+    if name in {"build_app", "run_tui"}:
+        from underthesea.agent.assistant import tui as _tui
+
+        return getattr(_tui, name)
+    raise AttributeError(f"module 'underthesea.agent.assistant' has no attribute {name!r}")

--- a/underthesea/agent/assistant/bridge.py
+++ b/underthesea/agent/assistant/bridge.py
@@ -1,0 +1,187 @@
+"""ClaudeBridge — async subprocess wrapper around the `claude` CLI.
+
+Spawns `claude --print --output-format=stream-json --verbose` for each user
+turn and yields parsed stream events. Auth comes from the user's existing
+`claude login`, so no API key is required.
+
+Schema of events (a few examples observed in the wild):
+    {"type": "system", "subtype": "init", "session_id": "...", "model": "..."}
+    {"type": "assistant", "message": {"content": [{"type": "text", "text": "..."}]}, "session_id": "..."}
+    {"type": "result", "subtype": "success", "result": "Hello", "total_cost_usd": 0.04, ...}
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+
+class BridgeError(RuntimeError):
+    """Raised when the claude subprocess fails or emits an unrecoverable event."""
+
+
+class ClaudeNotFoundError(BridgeError):
+    """Raised when the `claude` binary is missing from PATH."""
+
+    INSTALL_URL = "https://docs.claude.com/en/docs/claude-code/quickstart"
+
+    def __init__(self) -> None:
+        super().__init__(
+            "`claude` CLI not found in PATH.\n"
+            f"Install Claude Code: {self.INSTALL_URL}\n"
+            "Then run `claude login` to authenticate."
+        )
+
+
+@dataclass
+class StreamEvent:
+    """One parsed JSONL line from `claude --output-format=stream-json`."""
+
+    type: str
+    raw: dict
+    session_id: str | None = None
+
+    @property
+    def is_text_chunk(self) -> bool:
+        if self.type != "assistant":
+            return False
+        for block in self.raw.get("message", {}).get("content", []):
+            if block.get("type") == "text":
+                return True
+        return False
+
+    @property
+    def text(self) -> str:
+        """Concatenated text from all text blocks in an assistant event."""
+        if self.type != "assistant":
+            return ""
+        parts = []
+        for block in self.raw.get("message", {}).get("content", []):
+            if block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "".join(parts)
+
+    @property
+    def tool_use(self) -> dict | None:
+        """First tool_use block in this assistant event, if any."""
+        if self.type != "assistant":
+            return None
+        for block in self.raw.get("message", {}).get("content", []):
+            if block.get("type") == "tool_use":
+                return block
+        return None
+
+    @property
+    def is_done(self) -> bool:
+        return self.type == "result"
+
+    @property
+    def cost_usd(self) -> float | None:
+        if self.type == "result":
+            return self.raw.get("total_cost_usd")
+        return None
+
+
+class ClaudeBridge:
+    """Subprocess bridge to the local `claude` CLI.
+
+    Usage:
+        bridge = ClaudeBridge()
+        async for event in bridge.send("Hello"):
+            if event.is_text_chunk:
+                print(event.text, end="")
+            elif event.is_done:
+                print(f"\\n(cost: ${event.cost_usd:.4f})")
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        binary: str = "claude",
+        cwd: str | None = None,
+        extra_args: list[str] | None = None,
+    ) -> None:
+        self.binary = binary
+        self.model = model
+        self.cwd = cwd
+        self.extra_args = extra_args or []
+        self.session_id: str | None = None
+
+    def check(self) -> str:
+        """Resolve the `claude` binary path. Raises ClaudeNotFoundError if missing."""
+        path = shutil.which(self.binary)
+        if not path:
+            raise ClaudeNotFoundError()
+        return path
+
+    def _build_args(self, prompt: str) -> list[str]:
+        args = [
+            self.binary,
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        ]
+        if self.model:
+            args += ["--model", self.model]
+        if self.session_id:
+            args += ["--resume", self.session_id]
+        args += self.extra_args
+        args.append(prompt)
+        return args
+
+    async def send(self, prompt: str) -> AsyncIterator[StreamEvent]:
+        """Send a user prompt and yield StreamEvents as they arrive.
+
+        Updates self.session_id from the first system event so the next call
+        continues the conversation via --resume.
+        """
+        self.check()
+        args = self._build_args(prompt)
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.cwd,
+        )
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+
+        try:
+            async for event in self._parse_stream(proc.stdout):
+                if event.session_id and not self.session_id:
+                    self.session_id = event.session_id
+                yield event
+        finally:
+            await proc.wait()
+            if proc.returncode and proc.returncode != 0:
+                stderr_bytes = await proc.stderr.read()
+                raise BridgeError(
+                    f"claude exited with code {proc.returncode}: "
+                    f"{stderr_bytes.decode(errors='replace').strip()}"
+                )
+
+    @staticmethod
+    async def _parse_stream(
+        stdout: asyncio.StreamReader,
+    ) -> AsyncIterator[StreamEvent]:
+        async for line in stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            yield StreamEvent(
+                type=obj.get("type", "unknown"),
+                raw=obj,
+                session_id=obj.get("session_id"),
+            )
+
+    def reset(self) -> None:
+        """Forget the current session so the next send starts fresh."""
+        self.session_id = None

--- a/underthesea/agent/assistant/cli.py
+++ b/underthesea/agent/assistant/cli.py
@@ -6,6 +6,7 @@ do not use the assistant.
 from __future__ import annotations
 
 import sys
+from datetime import datetime
 
 import click
 
@@ -13,13 +14,20 @@ from underthesea.agent.assistant.bridge import ClaudeBridge, ClaudeNotFoundError
 from underthesea.agent.assistant.session import DEFAULT_DIR, Session
 
 
+def _new_session_name() -> str:
+    """Timestamp-based session name, e.g. ``2026-05-17_19-30-15``."""
+    return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+
 @click.command(name="assistant")
 @click.option(
     "--session",
     "session_name",
-    default="default",
-    show_default=True,
-    help="Session name. Resumes existing chat if the file already exists.",
+    default=None,
+    help=(
+        "Session name. Each invocation starts a fresh timestamped session "
+        "by default; pass an existing name to resume a saved chat."
+    ),
 )
 @click.option(
     "--memory-dir",
@@ -38,7 +46,7 @@ from underthesea.agent.assistant.session import DEFAULT_DIR, Session
     help="Verify the `claude` CLI is installed and exit.",
 )
 def assistant_command(
-    session_name: str,
+    session_name: str | None,
     memory_dir: str | None,
     model: str | None,
     check: bool,
@@ -47,6 +55,9 @@ def assistant_command(
 
     Uses your local `claude` CLI subscription as the LLM backend — no API key
     or token cost. Make sure you have run `claude login` once.
+
+    Each invocation starts a fresh timestamped session unless ``--session``
+    names a saved one to resume.
     """
     bridge = ClaudeBridge(model=model)
 
@@ -66,6 +77,9 @@ def assistant_command(
     from pathlib import Path
 
     directory = Path(memory_dir) if memory_dir else None
+    if session_name is None:
+        session_name = _new_session_name()
+        click.echo(f"new session: {session_name}", err=True)
     session = Session.open(session_name, directory)
     if session.claude_session_id:
         bridge.session_id = session.claude_session_id

--- a/underthesea/agent/assistant/cli.py
+++ b/underthesea/agent/assistant/cli.py
@@ -1,7 +1,7 @@
-"""Click command implementation for `underthesea assistant`.
+"""Click command implementation for `underthesea chat`.
 
 Imported lazily from underthesea.cli to keep startup time small for users who
-do not use the assistant.
+do not use the chat TUI.
 """
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ def _new_session_name() -> str:
     return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
 
-@click.command(name="assistant")
+@click.command(name="chat")
 @click.option(
     "--session",
     "session_name",
@@ -45,13 +45,13 @@ def _new_session_name() -> str:
     is_flag=True,
     help="Verify the `claude` CLI is installed and exit.",
 )
-def assistant_command(
+def chat_command(
     session_name: str | None,
     memory_dir: str | None,
     model: str | None,
     check: bool,
 ) -> None:
-    """Launch the Underthesea Assistant TUI.
+    """Launch the Underthesea chat TUI.
 
     Uses your local `claude` CLI subscription as the LLM backend — no API key
     or token cost. Make sure you have run `claude login` once.

--- a/underthesea/agent/assistant/cli.py
+++ b/underthesea/agent/assistant/cli.py
@@ -1,0 +1,83 @@
+"""Click command implementation for `underthesea assistant`.
+
+Imported lazily from underthesea.cli to keep startup time small for users who
+do not use the assistant.
+"""
+from __future__ import annotations
+
+import sys
+
+import click
+
+from underthesea.agent.assistant.bridge import ClaudeBridge, ClaudeNotFoundError
+from underthesea.agent.assistant.session import DEFAULT_DIR, Session
+
+
+@click.command(name="assistant")
+@click.option(
+    "--session",
+    "session_name",
+    default="default",
+    show_default=True,
+    help="Session name. Resumes existing chat if the file already exists.",
+)
+@click.option(
+    "--memory-dir",
+    type=click.Path(file_okay=False),
+    default=None,
+    help=f"Directory for session files. Defaults to {DEFAULT_DIR}.",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="Override the Claude model (e.g. 'sonnet', 'haiku', 'opus').",
+)
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Verify the `claude` CLI is installed and exit.",
+)
+def assistant_command(
+    session_name: str,
+    memory_dir: str | None,
+    model: str | None,
+    check: bool,
+) -> None:
+    """Launch the Underthesea Assistant TUI.
+
+    Uses your local `claude` CLI subscription as the LLM backend — no API key
+    or token cost. Make sure you have run `claude login` once.
+    """
+    bridge = ClaudeBridge(model=model)
+
+    try:
+        binary_path = bridge.check()
+    except ClaudeNotFoundError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
+
+    if check:
+        click.echo(f"claude: {binary_path}")
+        if model:
+            click.echo(f"model: {model}")
+        click.echo("OK")
+        return
+
+    from pathlib import Path
+
+    directory = Path(memory_dir) if memory_dir else None
+    session = Session.open(session_name, directory)
+    if session.claude_session_id:
+        bridge.session_id = session.claude_session_id
+    if session.model:
+        bridge.model = bridge.model or session.model
+    elif model:
+        session.model = model
+
+    from underthesea.agent.assistant.tui import run_tui
+
+    try:
+        run_tui(session, bridge)
+    except ImportError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)

--- a/underthesea/agent/assistant/session.py
+++ b/underthesea/agent/assistant/session.py
@@ -1,0 +1,114 @@
+"""Session — markdown-backed conversation log for the assistant.
+
+Each session is one file under ~/.underthesea/assistant/<name>.md (or a custom
+directory). The format is human-readable and intentionally compatible with the
+future MarkdownMemory abstraction (M2 of the roadmap).
+
+File layout:
+
+    # session: <name>
+    > created: 2026-05-17T18:00:00
+    > claude_session_id: <uuid>
+    > model: claude-sonnet-4-6
+
+    ## user — 2026-05-17T18:00:01
+    Hello
+
+    ## assistant — 2026-05-17T18:00:02
+    Hi! How can I help?
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_DIR = Path.home() / ".underthesea" / "assistant"
+
+
+@dataclass
+class Turn:
+    role: str  # "user" | "assistant"
+    content: str
+    ts: datetime = field(default_factory=datetime.now)
+
+
+class Session:
+    """Markdown-backed chat log.
+
+    Usage:
+        s = Session.open("my-chat")
+        s.append("user", "Hello")
+        s.append("assistant", "Hi!")
+        s.save()
+    """
+
+    HEADER_RE = re.compile(r"^# session: (.+)$", re.MULTILINE)
+    TURN_RE = re.compile(r"^## (user|assistant) — (.+)$", re.MULTILINE)
+
+    def __init__(self, name: str, path: Path) -> None:
+        self.name = name
+        self.path = path
+        self.turns: list[Turn] = []
+        self.claude_session_id: str | None = None
+        self.model: str | None = None
+
+    @classmethod
+    def open(cls, name: str, directory: Path | None = None) -> Session:
+        """Open or create a session by name. Loads existing turns if present."""
+        directory = directory or DEFAULT_DIR
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"{name}.md"
+        s = cls(name=name, path=path)
+        if path.exists():
+            s._load()
+        return s
+
+    def append(self, role: str, content: str) -> Turn:
+        turn = Turn(role=role, content=content)
+        self.turns.append(turn)
+        return turn
+
+    def save(self) -> None:
+        """Persist the session to disk. Overwrites the file atomically."""
+        text = self._serialize()
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(text, encoding="utf-8")
+        tmp.replace(self.path)
+
+    def _serialize(self) -> str:
+        lines = [f"# session: {self.name}"]
+        created = self.turns[0].ts if self.turns else datetime.now()
+        lines.append(f"> created: {created.isoformat(timespec='seconds')}")
+        if self.claude_session_id:
+            lines.append(f"> claude_session_id: {self.claude_session_id}")
+        if self.model:
+            lines.append(f"> model: {self.model}")
+        lines.append("")
+        for t in self.turns:
+            lines.append(f"## {t.role} — {t.ts.isoformat(timespec='seconds')}")
+            lines.append(t.content.rstrip())
+            lines.append("")
+        return "\n".join(lines) + "\n"
+
+    def _load(self) -> None:
+        text = self.path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if line.startswith("> claude_session_id: "):
+                self.claude_session_id = line.split(": ", 1)[1].strip()
+            elif line.startswith("> model: "):
+                self.model = line.split(": ", 1)[1].strip()
+
+        # Split on turn headers and reconstruct.
+        chunks = re.split(r"^## (user|assistant) — (\S+)\s*$", text, flags=re.MULTILINE)
+        # chunks = [preamble, role1, ts1, body1, role2, ts2, body2, ...]
+        for i in range(1, len(chunks) - 2, 3):
+            role = chunks[i]
+            ts_str = chunks[i + 1]
+            body = chunks[i + 2].strip()
+            try:
+                ts = datetime.fromisoformat(ts_str)
+            except ValueError:
+                ts = datetime.now()
+            self.turns.append(Turn(role=role, content=body, ts=ts))

--- a/underthesea/agent/assistant/tui.py
+++ b/underthesea/agent/assistant/tui.py
@@ -1,70 +1,139 @@
-"""Textual TUI app for the assistant.
+"""Textual TUI app for the assistant — OpenClaw-inspired minimal layout.
 
-Imports of `textual` are deferred so the rest of the assistant module can be
-imported without the `[assistant]` extra installed.
+No header bar, no widget borders, no per-message role labels. User input
+shows in a full-width slate bar; assistant replies render as plain text.
+A two-line status bar at the bottom mirrors OpenClaw's footer (state +
+agent / session / model / tokens).
+
+Imports of `textual` are deferred so the rest of the assistant module
+can be imported without the `[assistant]` extra installed.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 from underthesea.agent.assistant.bridge import ClaudeBridge
 from underthesea.agent.assistant.session import Session
+
+# Claude default context window. Used for the "tokens X/Y (Z%)" indicator.
+CONTEXT_WINDOW = 200_000
 
 
 def run_tui(session: Session, bridge: ClaudeBridge) -> None:
     """Launch the chat TUI. Blocks until the user quits.
 
-    Raises ImportError with a helpful message if the `[assistant]` extra is
-    not installed.
+    Raises ImportError with a helpful message if the `[assistant]` extra
+    is not installed.
     """
     try:
         from textual.app import App, ComposeResult
         from textual.binding import Binding
-        from textual.containers import Vertical
-        from textual.widgets import Footer, Header, Input, RichLog
+        from textual.containers import VerticalScroll
+        from textual.widgets import Input, Static
     except ImportError as e:
         raise ImportError(
             "The assistant TUI requires the `[assistant]` extra:\n"
             "    pip install 'underthesea[assistant]'"
         ) from e
 
+    class UserMessage(Static):
+        DEFAULT_CSS = """
+        UserMessage {
+            background: #2a3447;
+            color: #e6e6e6;
+            padding: 1 2;
+            margin: 0 0 1 0;
+            width: 100%;
+        }
+        """
+
+    class AssistantMessage(Static):
+        DEFAULT_CSS = """
+        AssistantMessage {
+            color: #e6e6e6;
+            padding: 0 2;
+            margin: 0 0 1 0;
+        }
+        """
+
+    class StatusBar(Static):
+        DEFAULT_CSS = """
+        StatusBar {
+            dock: bottom;
+            height: 2;
+            background: #0d1117;
+            color: #8b949e;
+            padding: 0 1;
+        }
+        """
+
     class AssistantApp(App):
         CSS = """
-        Screen { layout: vertical; }
-        RichLog { border: solid $accent; padding: 1; }
-        Input { dock: bottom; }
+        Screen {
+            background: #0d1117;
+        }
+        VerticalScroll#chat {
+            background: #0d1117;
+            scrollbar-size: 0 0;
+            padding: 1 0 0 0;
+        }
+        Input {
+            dock: bottom;
+            border: none;
+            background: #161b22;
+            color: #e6e6e6;
+            padding: 0 2;
+            height: 1;
+        }
+        Input:focus {
+            border: none;
+        }
         """
         BINDINGS = [
-            Binding("ctrl+c", "quit", "Quit"),
-            Binding("ctrl+l", "clear", "Clear"),
+            Binding("ctrl+c", "quit", "Quit", show=False),
+            Binding("ctrl+l", "clear", "Clear", show=False),
         ]
 
         def __init__(self) -> None:
             super().__init__()
             self.session = session
             self.bridge = bridge
+            self.tokens_used = 0
+            self.status_state = "idle"
 
         def compose(self) -> ComposeResult:
-            yield Header(show_clock=True)
-            yield Vertical(RichLog(id="log", wrap=True, markup=True))
-            yield Input(placeholder="Type a message and press Enter...", id="input")
-            yield Footer()
+            yield VerticalScroll(id="chat")
+            yield StatusBar(id="status")
+            yield Input(placeholder="", id="input")
 
         def on_mount(self) -> None:
-            log = self.query_one("#log", RichLog)
-            log.write(f"[dim]session: {self.session.name}[/dim]")
-            if self.bridge.model:
-                log.write(f"[dim]model: {self.bridge.model}[/dim]")
-            if self.bridge.session_id:
-                log.write(f"[dim]resuming claude session: {self.bridge.session_id}[/dim]")
-            log.write("")
+            chat = self.query_one("#chat", VerticalScroll)
             for turn in self.session.turns:
-                self._render_turn(turn.role, turn.content)
+                if turn.role == "user":
+                    chat.mount(UserMessage(turn.content))
+                else:
+                    chat.mount(AssistantMessage(turn.content))
+            self._refresh_status()
             self.query_one("#input", Input).focus()
 
-        def _render_turn(self, role: str, content: str) -> None:
-            log = self.query_one("#log", RichLog)
-            colour = "cyan" if role == "user" else "green"
-            log.write(f"[bold {colour}]{role}[/bold {colour}]: {content}")
-            log.write("")
+        def _refresh_status(self) -> None:
+            workspace = Path(self.bridge.cwd or ".").resolve()
+            workspace_name = workspace.name or "."
+            sid = self.bridge.session_id
+            sid_short = f"{sid[:8]}…" if sid else "—"
+            model = self.bridge.model or "default"
+            tokens_k = self.tokens_used / 1000
+            window_k = CONTEXT_WINDOW // 1000
+            pct = (self.tokens_used / CONTEXT_WINDOW) * 100 if self.tokens_used else 0
+
+            line1 = f"local ready | {self.status_state}"
+            line2 = (
+                f"agent {workspace_name} ({self.session.name}) | "
+                f"session {sid_short} | "
+                f"claude-cli/{model} | "
+                f"tokens {tokens_k:.1f}k/{window_k}k ({pct:.0f}%)"
+            )
+            self.query_one("#status", StatusBar).update(f"{line1}\n{line2}")
 
         async def on_input_submitted(self, message: Input.Submitted) -> None:
             text = message.value.strip()
@@ -74,40 +143,53 @@ def run_tui(session: Session, bridge: ClaudeBridge) -> None:
             input_widget.value = ""
             input_widget.disabled = True
 
+            chat = self.query_one("#chat", VerticalScroll)
+            chat.mount(UserMessage(text))
             self.session.append("user", text)
-            self._render_turn("user", text)
 
-            log = self.query_one("#log", RichLog)
-            log.write("[bold green]assistant[/bold green]: ", expand=True)
-            collected: list[str] = []
+            reply_widget = AssistantMessage("")
+            chat.mount(reply_widget)
+            chat.scroll_end(animate=False)
+
+            self.status_state = "thinking…"
+            self._refresh_status()
+
+            parts: list[str] = []
             try:
                 async for event in self.bridge.send(text):
                     if event.type == "system" and event.session_id:
                         self.session.claude_session_id = event.session_id
+                        self._refresh_status()
                     if event.is_text_chunk:
                         chunk = event.text
                         if chunk:
-                            collected.append(chunk)
-                            log.write(chunk)
-                    elif (tool := event.tool_use) is not None:
-                        log.write(f"[dim]→ tool: {tool.get('name')}[/dim]")
+                            parts.append(chunk)
+                            reply_widget.update("".join(parts))
+                            chat.scroll_end(animate=False)
                     elif event.is_done:
-                        cost = event.cost_usd
-                        if cost is not None:
-                            log.write(f"[dim](cost: ${cost:.4f})[/dim]")
+                        usage = event.raw.get("usage", {}) or {}
+                        self.tokens_used += (
+                            (usage.get("input_tokens") or 0)
+                            + (usage.get("output_tokens") or 0)
+                            + (usage.get("cache_read_input_tokens") or 0)
+                            + (usage.get("cache_creation_input_tokens") or 0)
+                        )
             except Exception as e:  # noqa: BLE001
-                log.write(f"[bold red]error:[/bold red] {e}")
+                reply_widget.update(f"[error] {e}")
             else:
-                reply = "".join(collected)
+                reply = "".join(parts).strip()
                 if reply:
                     self.session.append("assistant", reply)
                     self.session.save()
             finally:
-                log.write("")
+                self.status_state = "idle"
+                self._refresh_status()
                 input_widget.disabled = False
                 input_widget.focus()
 
         def action_clear(self) -> None:
-            self.query_one("#log", RichLog).clear()
+            chat = self.query_one("#chat", VerticalScroll)
+            for child in list(chat.children):
+                child.remove()
 
     AssistantApp().run()

--- a/underthesea/agent/assistant/tui.py
+++ b/underthesea/agent/assistant/tui.py
@@ -25,6 +25,15 @@ def run_tui(session: Session, bridge: ClaudeBridge) -> None:
     Raises ImportError with a helpful message if the `[assistant]` extra
     is not installed.
     """
+    build_app(session, bridge).run()
+
+
+def build_app(session: Session, bridge: ClaudeBridge):
+    """Construct the Textual app without running it.
+
+    Useful for snapshot tests (pytest-textual-snapshot) and other
+    inspection. Returns a non-running ``App`` instance.
+    """
     try:
         from textual.app import App, ComposeResult
         from textual.binding import Binding
@@ -59,8 +68,7 @@ def run_tui(session: Session, bridge: ClaudeBridge) -> None:
     class StatusBar(Static):
         DEFAULT_CSS = """
         StatusBar {
-            dock: bottom;
-            height: 2;
+            height: 1;
             background: #0d1117;
             color: #8b949e;
             padding: 0 1;
@@ -124,16 +132,14 @@ def run_tui(session: Session, bridge: ClaudeBridge) -> None:
             model = self.bridge.model or "default"
             tokens_k = self.tokens_used / 1000
             window_k = CONTEXT_WINDOW // 1000
-            pct = (self.tokens_used / CONTEXT_WINDOW) * 100 if self.tokens_used else 0
 
-            line1 = f"local ready | {self.status_state}"
-            line2 = (
-                f"agent {workspace_name} ({self.session.name}) | "
-                f"session {sid_short} | "
-                f"claude-cli/{model} | "
-                f"tokens {tokens_k:.1f}k/{window_k}k ({pct:.0f}%)"
+            status = (
+                f"{self.status_state} | "
+                f"{workspace_name}/{self.session.name} | "
+                f"{model} | {sid_short} | "
+                f"{tokens_k:.1f}k/{window_k}k"
             )
-            self.query_one("#status", StatusBar).update(f"{line1}\n{line2}")
+            self.query_one("#status", StatusBar).update(status)
 
         async def on_input_submitted(self, message: Input.Submitted) -> None:
             text = message.value.strip()
@@ -192,4 +198,4 @@ def run_tui(session: Session, bridge: ClaudeBridge) -> None:
             for child in list(chat.children):
                 child.remove()
 
-    AssistantApp().run()
+    return AssistantApp()

--- a/underthesea/agent/assistant/tui.py
+++ b/underthesea/agent/assistant/tui.py
@@ -1,0 +1,113 @@
+"""Textual TUI app for the assistant.
+
+Imports of `textual` are deferred so the rest of the assistant module can be
+imported without the `[assistant]` extra installed.
+"""
+from __future__ import annotations
+
+from underthesea.agent.assistant.bridge import ClaudeBridge
+from underthesea.agent.assistant.session import Session
+
+
+def run_tui(session: Session, bridge: ClaudeBridge) -> None:
+    """Launch the chat TUI. Blocks until the user quits.
+
+    Raises ImportError with a helpful message if the `[assistant]` extra is
+    not installed.
+    """
+    try:
+        from textual.app import App, ComposeResult
+        from textual.binding import Binding
+        from textual.containers import Vertical
+        from textual.widgets import Footer, Header, Input, RichLog
+    except ImportError as e:
+        raise ImportError(
+            "The assistant TUI requires the `[assistant]` extra:\n"
+            "    pip install 'underthesea[assistant]'"
+        ) from e
+
+    class AssistantApp(App):
+        CSS = """
+        Screen { layout: vertical; }
+        RichLog { border: solid $accent; padding: 1; }
+        Input { dock: bottom; }
+        """
+        BINDINGS = [
+            Binding("ctrl+c", "quit", "Quit"),
+            Binding("ctrl+l", "clear", "Clear"),
+        ]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.session = session
+            self.bridge = bridge
+
+        def compose(self) -> ComposeResult:
+            yield Header(show_clock=True)
+            yield Vertical(RichLog(id="log", wrap=True, markup=True))
+            yield Input(placeholder="Type a message and press Enter...", id="input")
+            yield Footer()
+
+        def on_mount(self) -> None:
+            log = self.query_one("#log", RichLog)
+            log.write(f"[dim]session: {self.session.name}[/dim]")
+            if self.bridge.model:
+                log.write(f"[dim]model: {self.bridge.model}[/dim]")
+            if self.bridge.session_id:
+                log.write(f"[dim]resuming claude session: {self.bridge.session_id}[/dim]")
+            log.write("")
+            for turn in self.session.turns:
+                self._render_turn(turn.role, turn.content)
+            self.query_one("#input", Input).focus()
+
+        def _render_turn(self, role: str, content: str) -> None:
+            log = self.query_one("#log", RichLog)
+            colour = "cyan" if role == "user" else "green"
+            log.write(f"[bold {colour}]{role}[/bold {colour}]: {content}")
+            log.write("")
+
+        async def on_input_submitted(self, message: Input.Submitted) -> None:
+            text = message.value.strip()
+            if not text:
+                return
+            input_widget = self.query_one("#input", Input)
+            input_widget.value = ""
+            input_widget.disabled = True
+
+            self.session.append("user", text)
+            self._render_turn("user", text)
+
+            log = self.query_one("#log", RichLog)
+            log.write("[bold green]assistant[/bold green]: ", expand=True)
+            collected: list[str] = []
+            try:
+                async for event in self.bridge.send(text):
+                    if event.type == "system" and event.session_id:
+                        self.session.claude_session_id = event.session_id
+                    if event.is_text_chunk:
+                        chunk = event.text
+                        if chunk:
+                            collected.append(chunk)
+                            log.write(chunk)
+                    elif (tool := event.tool_use) is not None:
+                        log.write(f"[dim]→ tool: {tool.get('name')}[/dim]")
+                    elif event.is_done:
+                        cost = event.cost_usd
+                        if cost is not None:
+                            log.write(f"[dim](cost: ${cost:.4f})[/dim]")
+            except Exception as e:  # noqa: BLE001
+                log.write(f"[bold red]error:[/bold red] {e}")
+            else:
+                reply = "".join(collected)
+                if reply:
+                    self.session.append("assistant", reply)
+                    self.session.save()
+            finally:
+                log.write("")
+                input_widget.disabled = False
+                input_widget.focus()
+
+        def action_clear(self) -> None:
+            self.query_one("#log", RichLog).clear()
+
+    AssistantApp().run()

--- a/underthesea/cli.py
+++ b/underthesea/cli.py
@@ -104,14 +104,15 @@ def info():
     print("           resources : OK")
 
 
-@main.command(name="web-chat")
+@main.command(name="agent")
 @click.option('--backend-port', default=8001, help='Backend API port')
 @click.option('--frontend-port', default=3000, help='Frontend port')
-def web_chat(backend_port, frontend_port):
-    """Start the Underthesea Chat web app (Next.js frontend + Node backend).
+def agent(backend_port, frontend_port):
+    """Start the Underthesea Agent web app (Next.js frontend + Node backend).
 
-    Renamed from `chat` in v9.6 so the shorter `underthesea chat` alias
-    can launch the local TUI assistant instead.
+    Renamed from `chat` → `web-chat` → `agent` over v9.6 so the shorter
+    `underthesea chat` alias is free for the local TUI, and this richer
+    multi-channel web UI gets the more accurate `agent` name.
     """
     # Find chat app directory
     underthesea_dir = Path(__file__).resolve().parent.parent

--- a/underthesea/cli.py
+++ b/underthesea/cli.py
@@ -178,8 +178,9 @@ def chat(backend_port, frontend_port):
 
 
 @main.command(name="assistant")
-@click.option('--session', 'session_name', default='default', show_default=True,
-              help='Session name. Resumes existing chat if the file already exists.')
+@click.option('--session', 'session_name', default=None,
+              help='Resume a saved chat by name. Omit to start a fresh '
+                   'timestamped session.')
 @click.option('--memory-dir', type=click.Path(file_okay=False), default=None,
               help='Directory for session files. Defaults to ~/.underthesea/assistant.')
 @click.option('--model', default=None,

--- a/underthesea/cli.py
+++ b/underthesea/cli.py
@@ -104,11 +104,15 @@ def info():
     print("           resources : OK")
 
 
-@main.command()
+@main.command(name="web-chat")
 @click.option('--backend-port', default=8001, help='Backend API port')
 @click.option('--frontend-port', default=3000, help='Frontend port')
-def chat(backend_port, frontend_port):
-    """Start the Underthesea Chat application (frontend + backend)."""
+def web_chat(backend_port, frontend_port):
+    """Start the Underthesea Chat web app (Next.js frontend + Node backend).
+
+    Renamed from `chat` in v9.6 so the shorter `underthesea chat` alias
+    can launch the local TUI assistant instead.
+    """
     # Find chat app directory
     underthesea_dir = Path(__file__).resolve().parent.parent
     chat_dir = underthesea_dir / "extensions" / "apps" / "chat"
@@ -177,7 +181,7 @@ def chat(backend_port, frontend_port):
         cleanup()
 
 
-@main.command(name="assistant")
+@main.command(name="chat")
 @click.option('--session', 'session_name', default=None,
               help='Resume a saved chat by name. Omit to start a fresh '
                    'timestamped session.')
@@ -187,11 +191,11 @@ def chat(backend_port, frontend_port):
               help="Override the Claude model (e.g. 'sonnet', 'haiku', 'opus').")
 @click.option('--check', is_flag=True, help='Verify the claude CLI is installed and exit.')
 @click.pass_context
-def assistant(ctx, session_name, memory_dir, model, check):
-    """Launch the Underthesea Assistant TUI (bridges to your local `claude` CLI)."""
-    from underthesea.agent.assistant.cli import assistant_command
+def chat(ctx, session_name, memory_dir, model, check):
+    """Launch the Underthesea chat TUI (bridges to your local `claude` CLI)."""
+    from underthesea.agent.assistant.cli import chat_command
     ctx.invoke(
-        assistant_command,
+        chat_command,
         session_name=session_name,
         memory_dir=memory_dir,
         model=model,

--- a/underthesea/cli.py
+++ b/underthesea/cli.py
@@ -177,6 +177,27 @@ def chat(backend_port, frontend_port):
         cleanup()
 
 
+@main.command(name="assistant")
+@click.option('--session', 'session_name', default='default', show_default=True,
+              help='Session name. Resumes existing chat if the file already exists.')
+@click.option('--memory-dir', type=click.Path(file_okay=False), default=None,
+              help='Directory for session files. Defaults to ~/.underthesea/assistant.')
+@click.option('--model', default=None,
+              help="Override the Claude model (e.g. 'sonnet', 'haiku', 'opus').")
+@click.option('--check', is_flag=True, help='Verify the claude CLI is installed and exit.')
+@click.pass_context
+def assistant(ctx, session_name, memory_dir, model, check):
+    """Launch the Underthesea Assistant TUI (bridges to your local `claude` CLI)."""
+    from underthesea.agent.assistant.cli import assistant_command
+    ctx.invoke(
+        assistant_command,
+        session_name=session_name,
+        memory_dir=memory_dir,
+        model=model,
+        check=check,
+    )
+
+
 _WIKI_CONFIG_DIR = Path.home() / ".config" / "underthesea"
 _WIKI_CONFIG_FILE = _WIKI_CONFIG_DIR / "wiki.json"
 


### PR DESCRIPTION
## Summary

Adds **`underthesea assistant`** — a Textual chat TUI that uses the user's local `claude` CLI as its LLM backend. No API key, no token cost beyond the user's existing Claude Code subscription.

Architecture borrows from OpenClaw / openclaw-zero-token: spawn `claude --print --output-format=stream-json --verbose`, parse JSONL events, resume by `session_id`.

```
underthesea assistant            ← Click subcommand
        ↓
Textual TUI (chat log + input)
        ↓ user message
ClaudeBridge.send(prompt)        ← async iterator of StreamEvent
        ↓ spawns
claude CLI (subscription auth)
        ↓ persists
Session (~/.underthesea/assistant/<name>.md)
```

## What's included

- `underthesea/agent/assistant/bridge.py` — `ClaudeBridge` async subprocess wrapper, JSONL parser, session-resume tracking, typed `StreamEvent` with `is_text_chunk` / `tool_use` / `is_done` / `cost_usd` properties.
- `underthesea/agent/assistant/session.py` — `Session` markdown-backed conversation log, atomic save, round-trip parser.
- `underthesea/agent/assistant/tui.py` — Textual app with `RichLog` history, `Input` box, token-streaming render, `Ctrl+L` clear. Textual import is deferred behind a helpful `ImportError`.
- `underthesea/agent/assistant/cli.py` + wiring in `underthesea/cli.py` — `@main.command(name='assistant')` with `--session`, `--memory-dir`, `--model`, `--check` flags.
- `pyproject.toml` — new `[assistant]` optional extra: `textual>=0.50`, `rich>=13.0`.
- 19 unit tests (subprocess mocked) covering stream parsing, session id pickup, non-zero exit, markdown round-trip.

## Manual smoke test

```bash
pip install -e '.[assistant]'
underthesea assistant --check
# claude: /Users/.../claude
# OK

underthesea assistant --model haiku
# (chat UI opens; messages stream token-by-token; session saved to ~/.underthesea/assistant/default.md)
```

End-to-end test confirmed against `claude haiku`:
- system init event surfaces model + session_id
- text streams chunk-by-chunk
- result event reports cost (0.012 USD for a 1-word reply)
- session resume works on subsequent calls

## Out of scope (deferred to follow-ups)

- No-output timeout / hung-subprocess watchdog (OpenClaw has `noOutputTimeoutMs`)
- Concurrent-call serialisation (KeyedAsyncQueue) — v1 user sends one prompt at a time
- Richer error classification (auth / billing / rate-limit) — current behaviour bubbles raw stderr

## Test plan

- [x] `python -m unittest tests.agent.assistant.*` — 19/19 pass
- [x] `ruff check underthesea/agent/assistant/ tests/agent/assistant/` — clean
- [x] `underthesea assistant --check` — resolves claude binary
- [x] Bridge live test with real `claude haiku` — streams correctly, session_id tracked
- [x] `underthesea info` still works (no regression to existing CLI)