### PR TITLE
Fix CRFFeaturizer ignoring column index in feature templates

### DIFF
--- a/extensions/underthesea_core/src/classifier/mod.rs
+++ b/extensions/underthesea_core/src/classifier/mod.rs
@@ -155,7 +155,7 @@ impl FastTfIdfVectorizer {
             .collect();
 
         // Sort by frequency (descending) and take top max_features
-        filtered.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        filtered.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
         filtered.truncate(self.max_features);
 
         // Build vocabulary and IDF

--- a/extensions/underthesea_core/src/featurizers.rs
+++ b/extensions/underthesea_core/src/featurizers.rs
@@ -73,6 +73,12 @@ impl CRFFeaturizer {
                     }
                     _ => (),
                 }
+                match cap.name("column") {
+                    Some(s) => {
+                        feature_template.column = s.as_str().parse::<isize>().unwrap();
+                    }
+                    _ => (),
+                }
                 match cap.name("function") {
                     Some(s) => {
                         feature_template.function = Option::from(String::from(s.as_str()));

--- a/extensions/underthesea_core/tests/featurizers.rs
+++ b/extensions/underthesea_core/tests/featurizers.rs
@@ -56,4 +56,109 @@ mod tests {
         let output = new_featurizer.process(sentences);
         assert_eq!(output, expected);
     }
+
+    #[test]
+    fn test_crf_featurizer_multiple_columns() {
+        let sentences = vec![vec![
+            vec![
+                "sinh".to_string(),
+                "N".to_string(),
+                "B-NP".to_string(),
+                "O".to_string(),
+            ],
+            vec![
+                "viên".to_string(),
+                "Np".to_string(),
+                "I-NP".to_string(),
+                "B-PER".to_string(),
+            ],
+            vec![
+                "đi".to_string(),
+                "V".to_string(),
+                "B-VP".to_string(),
+                "O".to_string(),
+            ],
+            vec![
+                "học".to_string(),
+                "V".to_string(),
+                "I-VP".to_string(),
+                "O".to_string(),
+            ],
+        ]];
+        let feature_configs = vec![
+            "T[0][0]".to_string(),
+            "T[0][1]".to_string(),
+            "T[0][2]".to_string(),
+            "T[0][3]".to_string(),
+        ];
+        let new_featurizer = CRFFeaturizer::new(feature_configs, HashSet::new());
+        let expected: Vec<Vec<Vec<String>>> = vec![vec![
+            vec![
+                "T[0][0]=sinh".to_string(),
+                "T[0][1]=N".to_string(),
+                "T[0][2]=B-NP".to_string(),
+                "T[0][3]=O".to_string(),
+            ],
+            vec![
+                "T[0][0]=viên".to_string(),
+                "T[0][1]=Np".to_string(),
+                "T[0][2]=I-NP".to_string(),
+                "T[0][3]=B-PER".to_string(),
+            ],
+            vec![
+                "T[0][0]=đi".to_string(),
+                "T[0][1]=V".to_string(),
+                "T[0][2]=B-VP".to_string(),
+                "T[0][3]=O".to_string(),
+            ],
+            vec![
+                "T[0][0]=học".to_string(),
+                "T[0][1]=V".to_string(),
+                "T[0][2]=I-VP".to_string(),
+                "T[0][3]=O".to_string(),
+            ],
+        ]];
+        let output = new_featurizer.process(sentences);
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_crf_featurizer_column_with_offset() {
+        let sentences = vec![vec![
+            vec![
+                "sinh".to_string(),
+                "N".to_string(),
+                "B-NP".to_string(),
+                "O".to_string(),
+            ],
+            vec![
+                "viên".to_string(),
+                "Np".to_string(),
+                "I-NP".to_string(),
+                "B-PER".to_string(),
+            ],
+            vec![
+                "đi".to_string(),
+                "V".to_string(),
+                "B-VP".to_string(),
+                "O".to_string(),
+            ],
+            vec![
+                "học".to_string(),
+                "V".to_string(),
+                "I-VP".to_string(),
+                "O".to_string(),
+            ],
+        ]];
+        let feature_configs = vec!["T[-1][2]".to_string(), "T[1][3]".to_string()];
+        let new_featurizer = CRFFeaturizer::new(feature_configs, HashSet::new());
+        let expected: Vec<Vec<Vec<String>>> = vec![vec![
+            vec!["T[-1][2]=BOS".to_string(), "T[1][3]=B-PER".to_string()],
+            vec!["T[-1][2]=B-NP".to_string(), "T[1][3]=O".to_string()],
+            vec!["T[-1][2]=I-NP".to_string(), "T[1][3]=O".to_string()],
+            vec!["T[-1][2]=B-VP".to_string(), "T[1][3]=EOS".to_string()],
+        ]];
+        let output = new_featurizer.process(sentences);
+        assert_eq!(output, expected);
+    }
 }

--- a/extensions/underthesea_core/tests/featurizers.rs
+++ b/extensions/underthesea_core/tests/featurizers.rs
@@ -36,4 +36,24 @@ mod tests {
         let output = new_featurizer.process(sentences);
         assert_eq!(output, expected);
     }
+
+    #[test]
+    fn test_crf_featurizer_column_index() {
+        let sentences = vec![vec![
+            vec!["sinh".to_string(), "A".to_string()],
+            vec!["viên".to_string(), "B".to_string()],
+            vec!["đi".to_string(), "C".to_string()],
+            vec!["học".to_string(), "D".to_string()],
+        ]];
+        let feature_configs = vec!["T[0][0]".to_string(), "T[0][1]".to_string()];
+        let new_featurizer = CRFFeaturizer::new(feature_configs, HashSet::new());
+        let expected: Vec<Vec<Vec<String>>> = vec![vec![
+            vec!["T[0][0]=sinh".to_string(), "T[0][1]=A".to_string()],
+            vec!["T[0][0]=viên".to_string(), "T[0][1]=B".to_string()],
+            vec!["T[0][0]=đi".to_string(), "T[0][1]=C".to_string()],
+            vec!["T[0][0]=học".to_string(), "T[0][1]=D".to_string()],
+        ]];
+        let output = new_featurizer.process(sentences);
+        assert_eq!(output, expected);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #1013: the column index in `CRFFeaturizer` feature templates (e.g. `T[0][1]`) was ignored, always reading column 0.
- Root cause: in `CRFFeaturizer::new`, the feature-template regex captured a `column` group, but the parsing loop never read `cap.name("column")`, so `FeatureTemplate.column` stayed at its default `0`.
- Fix: parse the captured `column` into `feature_template.column`, mirroring how `index1`/`index2` are handled.

This also fixes the reported Python usage, since `underthesea_core.CRFFeaturizer` wraps the same Rust struct.

## Test plan
- [x] Added Rust tests covering columns 0–3 and column indices combined with token offsets (including BOS/EOS boundaries)
- [x] `cargo test` passes