### PR TITLE
Release underthesea_core 3.3.1 (CRFFeaturizer column-index fix)

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -41,9 +41,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             extensions/underthesea_core/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('extensions/underthesea_core/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-v2-
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -82,9 +82,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             extensions/underthesea_core/target/
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-v2-${{ hashFiles('extensions/underthesea_core/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-build-
+            ${{ runner.os }}-cargo-build-v2-
 
       - name: Install maturin
         run: pip install maturin

--- a/extensions/underthesea_core/Cargo.toml
+++ b/extensions/underthesea_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "underthesea_core"
-version = "3.3.0"
+version = "3.3.1"
 homepage = "https://github.com/undertheseanlp/underthesea/tree/main/extensions/underthesea_core"
 repository = "https://github.com/undertheseanlp/underthesea/"
 authors = ["Vu Anh <anhv.ict91@gmail.com>"]


### PR DESCRIPTION
## Summary
- Bumps `underthesea_core` to **3.3.1** so the CRFFeaturizer column-index fix from #1030 / #1013 ships to PyPI and crates.io.
- Fixes the Rust CI cache key: `Cargo.lock` is gitignored, so `hashFiles('**/Cargo.lock')` was empty and the cache key was constant, restoring a stale `target/` that made the clippy step fail with exit 101 (no lint). The key is now derived from `Cargo.toml` with a salt so it invalidates correctly.

## Release
Merging this, then tagging `underthesea-core-v3.3.1`, triggers the PyPI and crates.io release workflows.

## Follow-up
Once 3.3.1 is published on PyPI, the `underthesea` dependency constraint will be bumped to `underthesea_core>=3.3.1` in a separate PR (kept separate to avoid breaking `pip install` CI before the package is live).

## Verification
- [x] Built the `3.3.1` wheel locally with maturin and ran the exact reproduction from #1013 — output is now `T[0][1]=A/B/C/D` as expected (was previously all column 0).
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass from a clean build on the same toolchain CI uses (1.95.0).