### PR TITLE
Auto-release underthesea_core on version bump to main

### DIFF
--- a/.github/workflows/release-crates-core.yml
+++ b/.github/workflows/release-crates-core.yml
@@ -2,8 +2,12 @@ name: Release underthesea_core to crates.io
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'extensions/underthesea_core/Cargo.toml'
+      - '.github/workflows/release-crates-core.yml'
     tags:
-      - 'underthesea-core-v*'  # Same tag as PyPI release (e.g. underthesea-core-v3.2.0)
+      - 'underthesea-core-v*'  # Manual tag release (e.g. underthesea-core-v3.2.0)
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,23 +16,43 @@ jobs:
   verify-version:
     name: Verify Version
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.check.outputs.should_release }}
     steps:
       - uses: actions/checkout@v4
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          CARGO_VERSION=$(grep '^version = ' extensions/underthesea_core/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Cargo.toml version: $CARGO_VERSION"
       - name: Verify tag matches Cargo.toml version
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/underthesea-core-v}"
-          CARGO_VERSION=$(grep '^version = ' extensions/underthesea_core/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "Tag version: $TAG_VERSION"
-          echo "Cargo.toml version: $CARGO_VERSION"
-          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
-            echo "ERROR: Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+          if [ "$TAG_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "ERROR: Tag version ($TAG_VERSION) does not match Cargo.toml version (${{ steps.version.outputs.version }})"
             exit 1
           fi
-          echo "✓ Versions match"
+          echo "✓ Tag matches Cargo.toml"
+      - name: Check whether version is already on crates.io
+        id: check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: underthesea-release-ci" "https://crates.io/api/v1/crates/underthesea_core/$VERSION")
+          if [ "$STATUS" = "200" ]; then
+            echo "underthesea_core $VERSION already on crates.io; nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "underthesea_core $VERSION not yet on crates.io; will release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
 
   publish:
     name: Publish to crates.io
     needs: verify-version
+    if: needs.verify-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release-pypi-core.yml
+++ b/.github/workflows/release-pypi-core.yml
@@ -2,8 +2,12 @@ name: Release underthesea_core
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'extensions/underthesea_core/Cargo.toml'
+      - '.github/workflows/release-pypi-core.yml'
     tags:
-      - 'underthesea-core-v*'  # Trigger on tags like underthesea-core-v3.1.0
+      - 'underthesea-core-v*'  # Manual tag release (e.g. underthesea-core-v3.1.0)
 
 env:
   PYPI_TOKEN: ${{ secrets.PYPI_UNDERTHESEA_CORE_API_TOKEN }}
@@ -12,23 +16,43 @@ jobs:
   verify-version:
     name: "Verify Version"
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.check.outputs.should_release }}
     steps:
       - uses: actions/checkout@v4
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          CARGO_VERSION=$(grep '^version = ' extensions/underthesea_core/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Cargo.toml version: $CARGO_VERSION"
       - name: Verify tag matches Cargo.toml version
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/underthesea-core-v}"
-          CARGO_VERSION=$(grep '^version = ' extensions/underthesea_core/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "Tag version: $TAG_VERSION"
-          echo "Cargo.toml version: $CARGO_VERSION"
-          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
-            echo "ERROR: Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+          if [ "$TAG_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "ERROR: Tag version ($TAG_VERSION) does not match Cargo.toml version (${{ steps.version.outputs.version }})"
             exit 1
           fi
-          echo "✓ Versions match"
+          echo "✓ Tag matches Cargo.toml"
+      - name: Check whether version is already on PyPI
+        id: check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/underthesea-core/$VERSION/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "underthesea-core $VERSION already on PyPI; nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "underthesea-core $VERSION not yet on PyPI; will release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
 
   sdist:
     name: "Source Distribution"
     needs: verify-version
+    if: needs.verify-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +73,7 @@ jobs:
   linux:
     name: "Linux ${{ matrix.target }}"
     needs: verify-version
+    if: needs.verify-version.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -77,6 +102,7 @@ jobs:
   musllinux:
     name: "Linux musl ${{ matrix.target }}"
     needs: verify-version
+    if: needs.verify-version.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -105,6 +131,7 @@ jobs:
   windows:
     name: "Windows x64"
     needs: verify-version
+    if: needs.verify-version.outputs.should_release == 'true'
     runs-on: windows-latest  # windows-2025
     steps:
     - uses: actions/checkout@v4
@@ -128,6 +155,7 @@ jobs:
   macos:
     name: "macOS ${{ matrix.target }}"
     needs: verify-version
+    if: needs.verify-version.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Makes `underthesea_core` release automatically, without a manually-pushed git tag.

- Both release workflows (`release-pypi-core.yml`, `release-crates-core.yml`) now also trigger on **push to `main`** when `extensions/underthesea_core/Cargo.toml` (or the workflow file) changes.
- The version is read from `Cargo.toml`; a guard checks whether that version is already on PyPI / crates.io and **skips the publish if it already exists** (idempotent — safe to re-run).
- The existing `underthesea-core-v*` tag trigger is kept as a manual fallback, with the same version check.

## Effect of merging this PR
Merging touches the workflow files (in the `paths` filter), so the push to `main` fires the release workflows. They read version **3.3.1** from `Cargo.toml`, find it is not yet published, and therefore **publish 3.3.1 to PyPI and crates.io**. From then on, any future version bump merged to `main` releases automatically.

## Follow-up
Once 3.3.1 is on PyPI, bump the `underthesea` dependency constraint to `underthesea_core>=3.3.1` (kept at `>=3.3.0` until the package is live to avoid breaking `pip install` CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_017zwD7W92H3uiYCdofnU9C3)_