### PR TITLE
Remove unused crfs dependency to fix underthesea_core build (GH-1033)

### DIFF
--- a/extensions/underthesea_core/Cargo.toml
+++ b/extensions/underthesea_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "underthesea_core"
-version = "3.3.1"
+version = "3.3.2"
 homepage = "https://github.com/undertheseanlp/underthesea/tree/main/extensions/underthesea_core"
 repository = "https://github.com/undertheseanlp/underthesea/"
 authors = ["Vu Anh <anhv.ict91@gmail.com>"]
@@ -33,7 +33,6 @@ harness = false
 serde = { version = "1.0", features = [ "derive" ] }
 regex = "1"
 rayon = "1.5"
-crfs = "0.1"
 
 # CRF implementation dependencies
 hashbrown = { version = "0.15", features = ["serde"] }  # Fast hash maps with serde support

--- a/extensions/underthesea_core/tests/models.rs
+++ b/extensions/underthesea_core/tests/models.rs
@@ -1,10 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use underthesea_core::crf::serialization::{CRFFormat, ModelLoader};
 
     #[test]
-    fn test_crfs() {
-        let buf = fs::read("tests/wt_crf_2018_09_13.bin").unwrap();
-        let _model = crfs::Model::new(&buf).unwrap();
+    fn test_load_crfsuite_model() {
+        let model = ModelLoader::new()
+            .load("tests/wt_crf_2018_09_13.bin", CRFFormat::Auto)
+            .unwrap();
+        assert!(model.num_labels > 0);
+        assert!(model.num_attributes > 0);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1033, where building `underthesea_core 3.3.1` failed while compiling the transitive `bstr 1.12.1` crate.

`bstr` is not a direct dependency — it was pulled in via `crfs 0.1.3 → cqdb 0.5.8 → bstr`. The `crfs` crate turned out to be dead weight: the library already has its own native CRF implementation in `src/crf/` (including a CRFsuite-format loader), and `crfs` was only referenced by a single test that exercised the external crate rather than our own code.

## Changes

- **`Cargo.toml`**: drop `crfs = "0.1"`. This removes `crfs`, `cqdb`, and both `bstr` versions from the dependency tree entirely (verified with `cargo tree`).
- **`tests/models.rs`**: rewrite the test to load the sample model through the native `ModelLoader` (`CRFFormat::Auto`), so it now tests our own loader and still passes against the real model file.
- **Version bump 3.3.1 → 3.3.2** so the fix can be published (the release workflow is gated on a `Cargo.toml` version change and skips versions already on PyPI).

## Test plan

- [x] `cargo tree` confirms `bstr`/`cqdb`/`crfs` are gone from the dependency graph
- [x] `cargo build --lib` succeeds without compiling `bstr`
- [x] `cargo test` — all 23 tests pass, including the rewritten `test_load_crfsuite_model`
- [x] CI builds wheels for Python 3.10–3.14 across platforms