### PR TITLE
feat(dependency_parse): batch inference with configurable batch_size and buckets

### DIFF
--- a/tests/pipeline/dependency_parse/test_dependency_parse.py
+++ b/tests/pipeline/dependency_parse/test_dependency_parse.py
@@ -31,3 +31,14 @@ class TestDependencyParse(TestCase):
         for sentence in actual:
             for token in sentence:
                 self.assertEqual(len(token), 3)
+
+    def test_batch_size_does_not_change_result(self):
+        # The torch-level batch_size only controls how many tokens share a
+        # forward pass; predictions must be identical regardless of its value.
+        texts = [
+            'Tối 29/11, Việt Nam thêm 2 ca mắc Covid-19',
+            'Tôi đi học',
+        ]
+        one_per_batch = dependency_parse(texts, batch_size=1)
+        large_batch = dependency_parse(texts, batch_size=5000)
+        self.assertEqual(one_per_batch, large_batch)

--- a/tests/pipeline/dependency_parse/test_dependency_parse.py
+++ b/tests/pipeline/dependency_parse/test_dependency_parse.py
@@ -17,3 +17,17 @@ class TestDependencyParse(TestCase):
                     ('mắc', 5, 'obj'),
                     ('Covid-19', 5, 'punct')]
         self.assertEqual(expected, actual)
+
+    def test_batch(self):
+        texts = [
+            'Tối 29/11, Việt Nam thêm 2 ca mắc Covid-19',
+            'Tôi đi học',
+        ]
+        actual = dependency_parse(texts)
+        self.assertEqual(len(actual), 2)
+        # batch result for the first text matches the single-text result
+        self.assertEqual(actual[0], dependency_parse(texts[0]))
+        # each parsed token is a (word, head, relation) triple
+        for sentence in actual:
+            for token in sentence:
+                self.assertEqual(len(token), 3)

--- a/underthesea/pipeline/dependency_parse/__init__.py
+++ b/underthesea/pipeline/dependency_parse/__init__.py
@@ -9,15 +9,23 @@ def init_parser():
     return uts_parser
 
 
+def _format_sentence(values):
+    return list(zip(values[1], values[6], values[7]))
+
+
 def dependency_parse(text):
     from underthesea import word_tokenize  # import here to avoid circular import
 
-    sentence = word_tokenize(text)
     parser = init_parser()
+
+    if isinstance(text, (list, tuple)):
+        sentences = [word_tokenize(t) for t in text]
+        dataset = parser.predict(sentences)
+        return [_format_sentence(sentence.values) for sentence in dataset.sentences]
+
+    sentence = word_tokenize(text)
     dataset = parser.predict([sentence])
-    results = dataset.sentences[0].values
-    results = list(zip(results[1], results[6], results[7]))
-    return results
+    return _format_sentence(dataset.sentences[0].values)
 
 
 # Lazy import visualization functions to avoid circular imports

--- a/underthesea/pipeline/dependency_parse/__init__.py
+++ b/underthesea/pipeline/dependency_parse/__init__.py
@@ -13,18 +13,34 @@ def _format_sentence(values):
     return list(zip(values[1], values[6], values[7]))
 
 
-def dependency_parse(text):
+def dependency_parse(text, batch_size=5000, buckets=8):
+    """Dependency parse one or many sentences.
+
+    Batching happens at the torch level inside the model: sentences are
+    grouped into ``buckets`` by length and each forward pass holds about
+    ``batch_size`` tokens, so a single ``predict`` call runs many sentences
+    through the network at once.
+
+    Args:
+        text (str or list[str]): a raw sentence, or a list of sentences.
+        batch_size (int): number of tokens per torch batch. Default: 5000.
+        buckets (int): number of length buckets used for batching. Default: 8.
+
+    Returns:
+        For a single ``str``: a list of ``(word, head, relation)`` tuples.
+        For a list of sentences: a list of such lists, in input order.
+    """
     from underthesea import word_tokenize  # import here to avoid circular import
 
     parser = init_parser()
 
     if isinstance(text, (list, tuple)):
         sentences = [word_tokenize(t) for t in text]
-        dataset = parser.predict(sentences)
+        dataset = parser.predict(sentences, batch_size=batch_size, buckets=buckets)
         return [_format_sentence(sentence.values) for sentence in dataset.sentences]
 
     sentence = word_tokenize(text)
-    dataset = parser.predict([sentence])
+    dataset = parser.predict([sentence], batch_size=batch_size, buckets=buckets)
     return _format_sentence(dataset.sentences[0].values)
 
 


### PR DESCRIPTION
## Summary
- Add batch inference support to `dependency_parse` so a list of sentences can be parsed in one call
- Expose underlying torch `batch_size` and `buckets` parameters for throughput tuning

## Changes
- `underthesea/pipeline/dependency_parse/__init__.py`: accept batched input and forward `batch_size` / `buckets`
- `tests/.../test_dependency_parse.py`: cover batch path

## Test plan
- [ ] `pytest underthesea/pipeline/dependency_parse/test_dependency_parse.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPAaWZicxZEh2RVWVUAiUD)_