### PR TITLE
feat(dependency_parse): batch inference for dependency parsing

### DIFF
--- a/tests/pipeline/dependency_parse/test_dependency_parse.py
+++ b/tests/pipeline/dependency_parse/test_dependency_parse.py
@@ -17,3 +17,23 @@ class TestDependencyParse(TestCase):
                     ('mắc', 5, 'obj'),
                     ('Covid-19', 5, 'punct')]
         self.assertEqual(expected, actual)
+
+    def test_batch(self):
+        texts = [
+            'Tối 29/11, Việt Nam thêm 2 ca mắc Covid-19',
+            'Tôi đi học',
+        ]
+        actual = dependency_parse(texts)
+        # one result per input sentence
+        self.assertEqual(len(actual), len(texts))
+        # batched results match single-sentence calls, in input order
+        self.assertEqual(actual[0], dependency_parse(texts[0]))
+        self.assertEqual(actual[1], dependency_parse(texts[1]))
+
+    def test_batch_params(self):
+        texts = ['Tôi đi học', 'Hà Nội là thủ đô của Việt Nam']
+        actual = dependency_parse(texts, batch_size=2000, buckets=2)
+        self.assertEqual(len(actual), len(texts))
+
+    def test_batch_empty(self):
+        self.assertEqual(dependency_parse([]), [])

--- a/tests/pipeline/dependency_parse/test_dependency_parse.py
+++ b/tests/pipeline/dependency_parse/test_dependency_parse.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
+from unittest.mock import patch
 from underthesea import dependency_parse
 
 
@@ -37,3 +38,15 @@ class TestDependencyParse(TestCase):
 
     def test_batch_empty(self):
         self.assertEqual(dependency_parse([]), [])
+
+    def test_batch_real_torch_batching(self):
+        # Equal-length sentences land in one length bucket and are run through a
+        # single torch forward pass (real batching, not a Python loop). This also
+        # guards a regression: batches larger than num_layers*2 used to crash.
+        from underthesea.pipeline.dependency_parse import init_parser
+        parser = init_parser()
+        texts = ['Tôi đi học'] * 16
+        with patch.object(parser, 'forward', wraps=parser.forward) as spy:
+            actual = dependency_parse(texts)
+        self.assertEqual(len(actual), 16)
+        self.assertEqual(spy.call_count, 1)

--- a/underthesea/modules/base.py
+++ b/underthesea/modules/base.py
@@ -189,8 +189,10 @@ class BiLSTM(nn.Module):
     def permute_hidden(self, hx, permutation):
         if permutation is None:
             return hx
-        h = hx[0].index_select(0, permutation)
-        c = hx[1].index_select(0, permutation)
+        # permute along the batch dimension (dim 1), not the layer dimension (dim 0);
+        # indexing dim 0 with batch indices crashes once batch_size > num_layers*2
+        h = hx[0].index_select(1, permutation)
+        c = hx[1].index_select(1, permutation)
 
         return h, c
 

--- a/underthesea/pipeline/dependency_parse/__init__.py
+++ b/underthesea/pipeline/dependency_parse/__init__.py
@@ -9,15 +9,37 @@ def init_parser():
     return uts_parser
 
 
-def dependency_parse(text):
+def dependency_parse(text, batch_size=5000, buckets=8):
+    """Dependency-parse a single sentence or a batch of sentences.
+
+    Args:
+        text (str or list[str]): a raw sentence, or a list of sentences.
+        batch_size (int): number of tokens per torch batch (token-level).
+            Passed straight to the model. Default: ``5000``.
+        buckets (int): number of length buckets used for batching. Default: ``8``.
+
+    Returns:
+        For a ``str`` input: a list of ``(word, head, relation)`` tuples
+        (backward compatible).
+        For a ``list[str]`` input: a list of such lists, one per sentence,
+        in the input order.
+    """
     from underthesea import word_tokenize  # import here to avoid circular import
 
-    sentence = word_tokenize(text)
+    single = isinstance(text, str)
+    texts = [text] if single else list(text)
+    if not texts:
+        return []
+
+    sentences = [word_tokenize(t) for t in texts]
     parser = init_parser()
-    dataset = parser.predict([sentence])
-    results = dataset.sentences[0].values
-    results = list(zip(results[1], results[6], results[7]))
-    return results
+    dataset = parser.predict(sentences, batch_size=batch_size, buckets=buckets)
+
+    results = []
+    for sentence in dataset.sentences:
+        values = sentence.values
+        results.append(list(zip(values[1], values[6], values[7])))
+    return results[0] if single else results
 
 
 # Lazy import visualization functions to avoid circular imports

--- a/underthesea/utils/sp_alg.py
+++ b/underthesea/utils/sp_alg.py
@@ -38,6 +38,10 @@ def kmeans(x, k, max_it=32):
     x, k = torch.tensor(x, dtype=torch.float), min(len(x), k)
     # collect unique datapoints
     d = x.unique()
+    # the number of clusters must not exceed the number of distinct lengths,
+    # otherwise empty clusters are forced open and produce duplicate centroids
+    # (which later collapse in `dict(zip(centroids, clusters))`, dropping sentences)
+    k = min(len(d), k)
     # initialize k centroids randomly
     c = d[torch.randperm(len(d))[:k]]
     # assign each datapoint to the cluster with the closest centroid


### PR DESCRIPTION
Related to #900 (does not auto-close)

`dependency_parse()` now exposes the torch-level batching that `DependencyParser.predict()` already does, so callers can parse many sentences in one batched pass and tune throughput.

```python
def dependency_parse(text, batch_size=5000, buckets=8):
    ...
```

- `text`: a raw sentence (`str`) **or** a list of sentences (`list[str]`).
- `batch_size`: tokens per torch batch (token-level). Default `5000`.
- `buckets`: number of length buckets used for batching. Default `8`.

**Behavior**
- A single `str` still returns a list of `(word, head, relation)` tuples (backward compatible).
- A `list[str]` runs through a single batched `predict()` call and returns a list of results **in input order** (order restored from the length buckets).
- Empty list returns `[]`.

```python
from underthesea import dependency_parse
results = dependency_parse(["Tối 29/11, Việt Nam thêm 2 ca mắc Covid-19", "Tôi đi học"])
results = dependency_parse(texts, batch_size=2000, buckets=4)  # tune torch batching
```

**Tests** — added `test_batch` (batched == single-call, in order), `test_batch_params`, `test_batch_empty`; all dependency_parse tests pass.