### PR TITLE
feat(tts): add VieNeu-TTS backend (default) alongside legacy VietTTS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ voice = [
     "matplotlib",
     "playsound3"
 ]
+speech = [
+    # VieNeu-TTS — default TTS backend. Core install is torch-free (ONNX on CPU);
+    # GPU users can additionally `pip install vieneu[gpu]`.
+    "vieneu>=3.0.4",
+    "playsound3"
+]
 prompt = [
     "openai"
 ]

--- a/underthesea/cli.py
+++ b/underthesea/cli.py
@@ -33,9 +33,11 @@ def download_model(model):
 
 @main.command()
 @click.argument('text', required=True)
-def tts(text):
+@click.option('--backend', default='vieneu', help="TTS backend: 'vieneu' (default) or 'viettts'")
+@click.option('--voice', default=None, help="Built-in voice name for the vieneu backend, e.g. 'Ngọc Linh'")
+def tts(text, backend, voice):
     from underthesea.pipeline.tts import tts as underthesea_tts
-    underthesea_tts(text, play=True)
+    underthesea_tts(text, play=True, backend=backend, voice=voice)
 
 
 @main.command()

--- a/underthesea/pipeline/tts/__init__.py
+++ b/underthesea/pipeline/tts/__init__.py
@@ -4,14 +4,50 @@ from os.path import join
 import numpy as np
 
 from underthesea.file_utils import MODELS_FOLDER
-from underthesea.pipeline.tts.viettts_ import nat_normalize_text
-from underthesea.pipeline.tts.viettts_.hifigan.mel2wave import mel2wave
-from underthesea.pipeline.tts.viettts_.nat.text2mel import text2mel
 
+# Legacy VietTTS V0.4.1 model location (used only by the "viettts" backend).
 model_path = join(MODELS_FOLDER, "VIET_TTS_V0_4_1")
 
+# Lazily-created VieNeu-TTS singleton (default backend).
+_VIENEU = None
 
-def text_to_speech(text):
+
+def _get_vieneu():
+    """Load VieNeu-TTS v3 Turbo once and cache it.
+
+    On CPU it runs torch-free via ONNX Runtime; on GPU it uses PyTorch — both are
+    selected automatically by ``Vieneu()``.
+    """
+    global _VIENEU
+    if _VIENEU is None:
+        try:
+            from vieneu import Vieneu
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "The 'vieneu' TTS backend requires the vieneu package. "
+                "Install it with `pip install underthesea[speech]` (or `pip install vieneu`)."
+            ) from e
+        _VIENEU = Vieneu()
+    return _VIENEU
+
+
+def _vieneu_synthesize(text, voice=None, ref_audio=None, **kwargs):
+    """VieNeu-TTS v3 Turbo → (sample_rate, int16 waveform)."""
+    engine = _get_vieneu()
+    wav = engine.infer(text, voice=voice, ref_audio=ref_audio, **kwargs)
+    y = (np.clip(np.asarray(wav, dtype=np.float32), -1.0, 1.0) * 32767).astype(np.int16)
+    return engine.sample_rate, y
+
+
+def _viettts_synthesize(text):
+    """Legacy VietTTS V0.4.1 (JAX/haiku) → (16000, int16 waveform).
+
+    Imported lazily so the default vieneu backend does not pull in jax/dm-haiku.
+    """
+    from underthesea.pipeline.tts.viettts_ import nat_normalize_text
+    from underthesea.pipeline.tts.viettts_.hifigan.mel2wave import mel2wave
+    from underthesea.pipeline.tts.viettts_.nat.text2mel import text2mel
+
     # prevent too long text
     if len(text) > 500:
         text = text[:500]
@@ -24,20 +60,51 @@ def text_to_speech(text):
         join(model_path, "duration_latest_ckpt.pickle"),
     )
     wave = mel2wave(mel, join(model_path, "config.json"), join(model_path, "hk_hifi.pickle"))
-    return (wave * (2**15)).astype(np.int16)
+    return 16_000, (wave * (2**15)).astype(np.int16)
 
 
-def tts(text, outfile="sound.wav", play=False):
-    y = text_to_speech(text)
-    # write y array to sound.wav
+def _synthesize(text, backend="vieneu", voice=None, ref_audio=None, **kwargs):
+    if backend == "vieneu":
+        return _vieneu_synthesize(text, voice=voice, ref_audio=ref_audio, **kwargs)
+    if backend == "viettts":
+        return _viettts_synthesize(text)
+    raise ValueError(f"Unknown TTS backend: {backend!r}. Use 'vieneu' or 'viettts'.")
+
+
+def text_to_speech(text, backend="vieneu", voice=None, ref_audio=None, **kwargs):
+    """Synthesize speech and return an ``int16`` numpy waveform.
+
+    Args:
+        text: the text to speak.
+        backend: ``"vieneu"`` (default) — VieNeu-TTS v3 Turbo: 48 kHz, many
+            built-in voices, instant voice cloning. ``"viettts"`` — legacy
+            VietTTS V0.4.1 (16 kHz, needs the ``[voice]`` extra and the
+            ``VIET_TTS_V0_4_1`` model).
+        voice: built-in voice name for the vieneu backend (e.g. ``"Ngọc Linh"``).
+        ref_audio: path to a 3–5 s reference clip to clone (vieneu backend).
+        **kwargs: forwarded to ``Vieneu.infer`` (temperature, top_k, ...).
+
+    Note: the vieneu backend returns 48 kHz audio (vs. 16 kHz for viettts); use
+    :func:`tts` if you need the matching sample rate written to disk.
+    """
+    return _synthesize(text, backend=backend, voice=voice, ref_audio=ref_audio, **kwargs)[1]
+
+
+def tts(text, outfile="sound.wav", play=False, backend="vieneu", voice=None, ref_audio=None, **kwargs):
+    """Synthesize ``text`` to ``outfile`` and optionally play it.
+
+    Returns ``(sample_rate, waveform)``. See :func:`text_to_speech` for backend
+    options (default ``"vieneu"``).
+    """
+    sr, y = _synthesize(text, backend=backend, voice=voice, ref_audio=ref_audio, **kwargs)
     import soundfile as sf
-    sf.write(outfile, y, 16_000)
+    sf.write(outfile, y, sr)
     time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
     print(f"\n{time_str}: {text}")
     if play:
         from playsound3 import playsound
         playsound(outfile)
-    return 16_000, y
+    return sr, y
 
 
 # Alias for backward compatibility


### PR DESCRIPTION
## Summary
Adds **VieNeu-TTS v3 Turbo** as a modern, pip-installable TTS backend for `underthesea.pipeline.tts`, and makes it the default.

- 48 kHz, many built-in Vietnamese voices, instant voice cloning (`ref_audio`)
- Core install is **torch-free** (ONNX Runtime on CPU, RTF < 1); GPU optional
- `pip install underthesea[speech]` — no jax/haiku, no separate model download

## Changes
- `text_to_speech()` / `tts()` / `say()` gain `backend=` (`"vieneu"` default, `"viettts"` legacy), plus `voice=` and `ref_audio=`.
- Legacy VietTTS (JAX/haiku) kept as `backend="viettts"`; its imports are now **lazy**, so the default backend no longer pulls in jax/dm-haiku.
- `tts()` writes the backend native sample rate (48 kHz vieneu vs 16 kHz viettts).
- CLI: `underthesea tts --backend --voice`.
- `pyproject.toml`: new `speech` extra (`vieneu`).

## Compatibility note
Default backend is now `vieneu`, so `tts("...")` requires `pip install underthesea[speech]`. Existing VietTTS users keep the old behavior with `backend="viettts"`. Happy to flip the default to opt-in if you prefer.

## Disclosure
I am the author of VieNeu-TTS. underthesea TTS currently relies on an older VietTTS model; VieNeu offers more voices, voice cloning, and much faster inference, and installs via pip. Happy to adjust the approach to your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)