### PR TITLE
fix(tts): use raise from to preserve exception chain (ruff B904)

### DIFF
--- a/underthesea/pipeline/tts/__init__.py
+++ b/underthesea/pipeline/tts/__init__.py
@@ -32,11 +32,11 @@ def _synthesize_viettts(text):
 def _synthesize_vieneu(text):
     try:
         from vieneu import Vieneu
-    except ImportError:
+    except ImportError as err:
         raise ImportError(
             "The 'vieneu' package is required for backend='vieneu'. "
             "Install it with: pip install underthesea[voice-vieneu]"
-        )
+        ) from err
 
     import numpy as np
     engine = Vieneu()


### PR DESCRIPTION
## Summary
- Fix ruff B904 lint error in `underthesea/pipeline/tts/__init__.py` by using `raise ... from err` in the `except ImportError` clause to preserve the exception chain

## Test plan
- [x] `ruff check` passes locally