### PR TITLE
fix(classification): stop polluting host app root logger at import

### DIFF
--- a/underthesea/pipeline/classification/__init__.py
+++ b/underthesea/pipeline/classification/__init__.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 from underthesea.file_utils import UNDERTHESEA_FOLDER, cached_path
 
-FORMAT = "%(message)s"
-logging.basicConfig(format=FORMAT)
 logger = logging.getLogger("underthesea")
 
 # Model configurations


### PR DESCRIPTION
## Description
`underthesea/pipeline/classification/__init__.py` calls `logging.basicConfig()` at import time, which attaches a `StreamHandler` to the host application's root logger. Any application importing `underthesea` is unable to configure logging normally, the application's own `basicConfig()` call becomes a no-op unless `force=True` is used to override it.

Fixed by removing the `FORMAT`/`logging.basicConfig()` call, leaving only `logger = logging.getLogger("underthesea")`.

## Reason for Change
According to the Python Logging HOWTO:

> "You are strongly advised against adding any handlers other than `NullHandler` to your library’s loggers."
> — https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library

`logging.basicConfig()` does nothing if the root logger already has any handlers configured, so calling it from a library silently hijacks the caller's logging configuration.

## Testing
- [x] Passed linting — `ruff check underthesea/pipeline/classification/__init__.py` (clean)
- [x] `tests/pipeline/classification/test_bank.py` — 6/6 passed
- [x] `tests/pipeline/classification/test_general.py` — 9/9 passed
- [x] Manual: after `import underthesea.pipeline.classification`, the root logger is no longer polluted with additional handlers (handlers remain `[]` before and after import)