### PR TITLE
fix: default models for both providers have been retired upstream

### DIFF
--- a/underthesea/agent/providers/anthropic_provider.py
+++ b/underthesea/agent/providers/anthropic_provider.py
@@ -15,7 +15,7 @@ class Anthropic(BaseProvider):
     >>> llm = Anthropic()  # uses ANTHROPIC_API_KEY env var
     """
 
-    DEFAULT_MODEL = "claude-sonnet-4-20250514"
+    DEFAULT_MODEL = "claude-sonnet-5"
     BASE_URL = "https://api.anthropic.com"
     API_VERSION = "2023-06-01"
 

--- a/underthesea/agent/providers/gemini_provider.py
+++ b/underthesea/agent/providers/gemini_provider.py
@@ -16,7 +16,7 @@ class Gemini(BaseProvider):
     >>> llm = Gemini()  # uses GOOGLE_API_KEY env var
     """
 
-    DEFAULT_MODEL = "gemini-2.0-flash"
+    DEFAULT_MODEL = "gemini-3.5-flash"
     BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 
     def __init__(self, api_key: str | None = None, model: str | None = None):


### PR DESCRIPTION
Both agent providers currently default to models that have been shut down, so anyone calling them without passing an explicit `model` gets an API error instead of a response.

**`underthesea/agent/providers/anthropic_provider.py:18`**
`DEFAULT_MODEL = "claude-sonnet-4-20250514"` was retired on 2026-06-15.

**`underthesea/agent/providers/gemini_provider.py:19`**
`DEFAULT_MODEL = "gemini-2.0-flash"` was shut down on 2026-06-01, per Google's changelog: https://ai.google.dev/gemini-api/docs/changelog

This updates each to the replacement the provider names, and changes nothing else. Happy to split it into two commits, or to drop either half if you would rather pin a different version.

For what it is worth, the OpenAI provider defaults to `gpt-4-turbo`, which OpenAI has scheduled for shutdown on 2026-10-23. It still works today, so I have deliberately left it alone.

Found while testing [driftcite](https://github.com/nilaypatell/driftcite), a tool I am building that checks code against providers' published deprecation notices.