### PR TITLE
Fix fixed_words leaking across tokenize() calls via a module global

### DIFF
--- a/tests/pipeline/word_tokenize/test_tokenize.py
+++ b/tests/pipeline/word_tokenize/test_tokenize.py
@@ -279,3 +279,15 @@ class TestTokenize(TestCase):
         actual = tokenize(text, fixed_words=fixed_words)
         expected = ['Viện Nghiên Cứu', 'chiến', 'lược', 'quốc', 'gia', 'về', 'học máy']
         self.assertEqual(expected, actual)
+
+    def test_fixed_words_do_not_leak_into_later_calls(self):
+        # A call that passes `fixed_words` must not mutate global state used by
+        # subsequent calls. Previously `fixed_words` was compiled into the
+        # module-level `patterns` global, so a later call with no `fixed_words`
+        # kept merging the earlier call's fixed words.
+        text = "Viện Nghiên Cứu chiến lược quốc gia"
+        clean = tokenize(text)
+        tokenize(text, fixed_words=["Viện Nghiên Cứu", "chiến lược"])
+        clean_again = tokenize(text)
+        self.assertEqual(clean, clean_again)
+        self.assertNotIn("Viện Nghiên Cứu", clean_again)

--- a/underthesea/pipeline/word_tokenize/regex_tokenize.py
+++ b/underthesea/pipeline/word_tokenize/regex_tokenize.py
@@ -231,7 +231,6 @@ regex_patterns = [
     symbol,
     non_word  # non_word must be last
 ]
-recompile_regex_patterns = False
 regex_patterns_combine = r"(" + "|".join(regex_patterns) + ")"
 patterns = re.compile(regex_patterns_combine, re.VERBOSE | re.UNICODE)
 
@@ -258,18 +257,19 @@ def tokenize(text, format=None, tag=False, use_character_normalize=True, use_tok
     """
     if fixed_words is None:
         fixed_words = []
-    global recompile_regex_patterns
-    global patterns
+    # Use a per-call pattern. `fixed_words` is caller-supplied, so compiling it
+    # into the module-level `patterns` global leaked one call's fixed words into
+    # every subsequent call in the process (and was not thread-safe).
+    active_patterns = patterns
     if len(fixed_words) > 0:
         compiled_fixed_words = [re.sub(" ", r"\ ", fixed_word) for fixed_word in fixed_words]
         fixed_words_pattern = "(?P<fixed_words>\\b" + "\\b|\\b".join(compiled_fixed_words) + "\\b)"
         merged_regex_patterns = [fixed_words_pattern] + regex_patterns
         regex_patterns_combine = r"(" + "|".join(merged_regex_patterns) + ")"
-        patterns = re.compile(regex_patterns_combine, re.VERBOSE | re.UNICODE)
-        recompile_regex_patterns = True
+        active_patterns = re.compile(regex_patterns_combine, re.VERBOSE | re.UNICODE)
     if use_character_normalize:
         text = normalize_characters_in_text(text)
-    matches = list(re.finditer(patterns, text))
+    matches = list(re.finditer(active_patterns, text))
     tokens = [extract_match(m) for m in matches]
 
     if tag:


### PR DESCRIPTION
## Problem

`tokenize()` in `underthesea/pipeline/word_tokenize/regex_tokenize.py` compiles a caller's `fixed_words` into the **module-level** `patterns` global and then matches against it:

```python
global recompile_regex_patterns
global patterns
if len(fixed_words) > 0:
    ...
    patterns = re.compile(regex_patterns_combine, ...)   # overwrites the module global
    recompile_regex_patterns = True                       # set but never read anywhere
...
matches = list(re.finditer(patterns, text))               # uses the (now polluted) global
```

The global is never restored, so the `fixed_words` from **one** call silently leak into **every later** call in the same process — including the public `word_tokenize` API — and this is not thread-safe. `recompile_regex_patterns` is write-only (assigned, never read): a leftover of an intended-but-never-implemented reset.

Reproduction on current `main`:
```python
tokenize("Viện Nghiên Cứu chiến lược quốc gia",
         fixed_words=["Viện Nghiên Cứu", "chiến lược"])
# -> ['Viện Nghiên Cứu', 'chiến lược', 'quốc', 'gia']   (correct)

tokenize("Viện Nghiên Cứu chiến lược quốc gia")          # NO fixed_words
# -> ['Viện Nghiên Cứu', 'chiến lược', 'quốc', 'gia']   (WRONG — leaked)
# expected: ['Viện', 'Nghiên', 'Cứu', 'chiến', 'lược', 'quốc', 'gia']
```

The existing `fixed_words` tests never caught this because every one of them passes `fixed_words` on every call (`test_fixed_words_multi_calls` chains two `fixed_words` calls and never a clean call afterward).

## Fix

Compile the per-call pattern into a **local** variable (`active_patterns`) and never touch the module global; remove the dead `recompile_regex_patterns` flag. Behavior for any single call is unchanged; state no longer bleeds between calls (and it's thread-safe).

## Test

`test_fixed_words_do_not_leak_into_later_calls`: tokenize cleanly, once with `fixed_words`, then cleanly again, and assert the two clean results are equal (and that the earlier fixed words didn't leak in). It fails on `main` and passes with the fix. All existing tokenize tests (32) still pass.